### PR TITLE
chore: OSS scaffolding (PR 1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Describe the bug
+
+<!-- A clear, concise description of what went wrong. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual behaviour
+
+<!-- What actually happened. Include error output or stack traces. -->
+
+## Environment
+
+- plynth version:
+- Python version:
+- OS:
+- GitHub target (github.com / GHES version):
+
+## Template and instance config
+
+<!-- Paste a minimal template + instance config that reproduces the issue.
+     Remove any sensitive values (tokens, org names, repo names) before posting. -->
+
+```yaml
+# template
+```
+
+```yaml
+# instance
+```
+
+## State file (if applicable)
+
+<!-- If the failure occurred mid-run, paste the relevant section of the state file
+     (*.plynth-state.yaml). Remove node_ids if sensitive. -->
+
+## Additional context
+
+<!-- Anything else that might be relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+labels: enhancement
+---
+
+## Summary
+
+<!-- One or two sentences: what you want and why. -->
+
+## Motivation
+
+<!-- What problem does this solve? What is the current workaround, if any? -->
+
+## Proposed behaviour
+
+<!-- Describe the desired behaviour as concretely as possible.
+     If this affects the template or instance config schema, show example YAML. -->
+
+```yaml
+# example
+```
+
+## Alternatives considered
+
+<!-- Other approaches you thought about and why you prefer this one. -->
+
+## Additional context
+
+<!-- Links, related issues, prior art in similar tools, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do and why? Link to the issue it resolves if applicable.
+     Fixes #<issue> -->
+
+## Changes
+
+<!-- Bullet list of what changed. -->
+
+-
+
+## Testing
+
+<!-- How was this tested? Check all that apply. -->
+
+- [ ] New unit tests added (`tests/`)
+- [ ] Existing tests pass (`pytest -q`)
+- [ ] Tested manually against a live instance (describe below)
+- [ ] No testable behaviour change (docs, config, refactor)
+
+<!-- If manually tested, describe what you tested: -->
+
+## Checklist
+
+- [ ] `ruff check .` passes
+- [ ] `ruff format --check .` passes
+- [ ] `mypy plynth` passes
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
+- [ ] No tokens, credentials, or org-specific names committed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to plynth are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+- LICENSE (Apache 2.0)
+- CHANGELOG.md
+- CONTRIBUTING.md
+- SECURITY.md
+- GitHub issue and PR templates (`.github/`)
+
+---
+
+## [0.1.0] — 2026-05-01
+
+Initial release. Core engine complete and functional against GHES 3.19.
+
+### Added
+- **Template schema** (`plynth/models/template.py`) — Pydantic v2 models for
+  `TemplateDefinition`, `FieldDefinition`, `MilestoneDefinition`, `IssueDefinition`,
+  placeholder specs, status options, views, and pruning rules.
+- **Instance config schema** (`plynth/models/instance.py`) — `InstanceConfig`,
+  `RepoConfig`, `ProjectConfig` with validators (URL trailing-slash trim, date format).
+- **Execution plan model** (`plynth/models/plan.py`) — `ExecutionPlan`,
+  `ResolvedIssue`, `ResolvedMilestone`, `ResolvedField`.
+- **State file model** (`plynth/models/state.py`) — `StateFile` with per-phase
+  checkpoint tracking, SHA-256 template/instance hashes, and resume support.
+- **Planner** (`plynth/engine/planner.py`) — pure computation: placeholder
+  resolution, milestone/issue filtering (skip_milestones, skip_issues, pruning),
+  dependency graph trimming, dry-run formatter.
+- **GraphQL client** (`plynth/engine/graphql_client.py`) — all Phase 1–5 mutations
+  and preflight queries; write delay enforcement; retry on 429/503.
+- **REST client** (`plynth/engine/rest_client.py`) — milestone creation via
+  `POST /repos/{owner}/{repo}/milestones` (only REST operation; createMilestone
+  not available in GHES 3.19 GraphQL).
+- **Base HTTP client** (`plynth/engine/api_base.py`) — `GHESClient` with Bearer
+  auth, configurable write delay, and exponential-backoff retry.
+- **Phase orchestrator** (`plynth/engine/phases.py`) — Phases 1–7 with state
+  checkpointing and resume logic.
+- **Cross-reference resolver** (`plynth/utils/references.py`) — `{PREFIX}-###`
+  → `#real_number` substitution with longest-first matching and skipped-ref
+  strikethrough.
+- **CLI** (`plynth/cli.py`) — `plynth create` and `plynth resolve` subcommands;
+  `--dry-run`, `--token`, `--state-dir`, `--write-delay-ms`, `--verbose`.
+- **GraphQL query/mutation strings** (`plynth/queries/`) — all mutations and
+  queries as module-level constants.
+- **Sanitized agent-reference docs** (`docs/`) — design spec, orchestrator spec,
+  planner spec, API client spec, example template (17 issues, 5 milestones),
+  and example instance config.
+
+[Unreleased]: https://github.com/Declaratus/plynth/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Declaratus/plynth/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,7 @@ cd plynth
 pip install -e ".[dev]"
 ```
 
-The `[dev]` extra (added in v0.2) includes pytest, ruff, and mypy.
-Until v0.2 is released, install dev dependencies manually:
-
-```bash
-pip install pytest pytest-mock responses ruff mypy types-requests types-PyYAML
-pip install -e .
-```
+The `[dev]` extra includes pytest, ruff, mypy, and the test helpers.
 
 ## Running tests
 
@@ -27,13 +21,20 @@ no live GitHub or GHES instance required.
 
 ## Lint and type-check
 
+Check (what CI runs — must pass before opening a PR):
+
 ```bash
 ruff check .
 ruff format --check .
 mypy plynth
 ```
 
-All three must pass cleanly before opening a PR.
+Apply formatting locally (modifies files in place):
+
+```bash
+ruff format .
+```
+
 Configuration lives in `pyproject.toml` under `[tool.ruff]` and `[tool.mypy]`.
 
 ## Commit messages
@@ -55,7 +56,7 @@ Reference issues where applicable: `fixes #42`.
 
 1. Fork or branch from `main`.
 2. Make changes. Add or update tests for any behaviour change.
-3. Run `ruff check .`, `ruff format .`, `mypy plynth`, and `pytest -q` locally.
+3. Run `ruff check .`, `ruff format --check .`, `mypy plynth`, and `pytest -q` locally.
 4. Update `CHANGELOG.md` under `## [Unreleased]`.
 5. Open a PR against `main`. Fill in the PR template.
 6. CI must pass before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to plynth
+
+## Development setup
+
+```bash
+git clone https://github.com/Declaratus/plynth.git
+cd plynth
+pip install -e ".[dev]"
+```
+
+The `[dev]` extra (added in v0.2) includes pytest, ruff, and mypy.
+Until v0.2 is released, install dev dependencies manually:
+
+```bash
+pip install pytest pytest-mock responses ruff mypy types-requests types-PyYAML
+pip install -e .
+```
+
+## Running tests
+
+```bash
+pytest -q
+```
+
+Tests live in `tests/`. The suite uses `responses` to mock all HTTP calls —
+no live GitHub or GHES instance required.
+
+## Lint and type-check
+
+```bash
+ruff check .
+ruff format --check .
+mypy plynth
+```
+
+All three must pass cleanly before opening a PR.
+Configuration lives in `pyproject.toml` under `[tool.ruff]` and `[tool.mypy]`.
+
+## Commit messages
+
+Use the conventional commit format:
+
+```
+<type>: <short description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+Keep the subject line under 72 characters.
+Reference issues where applicable: `fixes #42`.
+
+## Pull request flow
+
+1. Fork or branch from `main`.
+2. Make changes. Add or update tests for any behaviour change.
+3. Run `ruff check .`, `ruff format .`, `mypy plynth`, and `pytest -q` locally.
+4. Update `CHANGELOG.md` under `## [Unreleased]`.
+5. Open a PR against `main`. Fill in the PR template.
+6. CI must pass before merge.
+
+## Authentication in tests
+
+Tests must never use real tokens or make real API calls.
+All HTTP interactions are mocked via the `responses` library.
+Never commit `GHES_TOKEN` or any credential to the repository — see [SECURITY.md](SECURITY.md).
+
+## Scope
+
+plynth is intentionally minimal in its runtime dependencies (pydantic, pyyaml, requests).
+Before adding a dependency, consider whether the functionality can be
+implemented without it. Open an issue to discuss if unsure.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,179 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other transformations
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and incorporated
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any Contribution
+      embodied within the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this License
+      for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the
+          License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Derivative Works as permitted by this section.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of TITLE,
+      MERCHANTIBILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+      responsible for determining the appropriateness of using or
+      redistributing the Work and assume any risks associated with Your
+      exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer only conditions that are
+      consistent with this License and offer such obligations for a fee.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Barry Johnston
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -32,33 +33,36 @@
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-      "Work" shall mean the work of authorship made available under
-      the License, as indicated by a copyright notice that is included in
-      or attached to the work (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other transformations
+      editorial revisions, annotations, elaborations, or other modifications
       represent, as a whole, an original work of authorship. For the purposes
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
 
-      "Contribution" shall mean, as submitted to the Licensor for inclusion
-      in the Work by the copyright owner or by an individual or Legal Entity
-      authorized to submit on behalf of the copyright owner. For the purposes
-      of this definition, "submitted" means any form of electronic, verbal,
-      or written communication sent to the Licensor or its representatives,
-      including but not limited to communication on electronic mailing lists,
-      source code control systems, and issue tracking systems that are managed
-      by, or on behalf of, the Licensor for the purpose of discussing and
-      improving the Work, but excluding communication that is conspicuously
-      marked or designated in writing by the copyright owner as "Not a
-      Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any Legal Entity on behalf of
-      whom a Contribution has been received by the Licensor and incorporated
-      within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -74,21 +78,22 @@
       use, offer to sell, sell, import, and otherwise transfer the Work,
       where such license applies only to those patent claims licensable
       by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by the combination of their Contribution(s)
+      Contribution(s) alone or by combination of their Contribution(s)
       with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a cross-claim
-      or counterclaim in a lawsuit) alleging that the Work or any Contribution
-      embodied within the Work constitutes direct or contributory patent
-      infringement, then any patent licenses granted to You under this License
-      for that Work shall terminate as of the date such litigation is filed.
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
 
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
@@ -100,25 +105,28 @@
           the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, You must include a readable copy of the
-          attribution notices contained within such NOTICE file, in
-          at least one of the following places: within a NOTICE text
-          file distributed as part of the Derivative Works; within
-          the Source form or documentation, if provided along with the
-          Derivative Works; or, within a display generated by the
-          Derivative Works, if and wherever such third-party notices
-          normally appear. The contents of the NOTICE file are for
-          informational purposes only and do not modify the License.
-          You may add Your own attribution notices within Derivative
-          Works that You distribute, alongside or in addition to the
-          NOTICE text from the Work, provided that such additional
-          attribution notices cannot be construed as modifying the
-          License.
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-      You may add Your own license statement for Your modifications and
-      may provide additional grant of rights to use, copy, modify, merge,
-      publish, distribute, sublicense, and/or sell copies of the
-      Derivative Works as permitted by this section.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
@@ -137,34 +145,49 @@
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any conditions of TITLE,
-      MERCHANTIBILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
-      responsible for determining the appropriateness of using or
-      redistributing the Work and assume any risks associated with Your
-      exercise of permissions under this License.
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
    8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
       liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a
+      incidental, or consequential damages of any character arising as a
       result of this License or out of the use or inability to use the
       Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or all other
-      commercial damages or losses), even if such Contributor has been
-      advised of the possibility of such damages.
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Liability. While redistributing the Work or
-      Derivative Works thereof, You may choose to offer, and charge a fee
-      for, acceptance of support, warranty, indemnity, or other liability
-      obligations and/or rights consistent with this License. However, in
-      accepting such obligations, You may offer only conditions that are
-      consistent with this License and offer such obligations for a fee.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Barry Johnston
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,10 @@ plynth requires a GitHub Personal Access Token (PAT) with `repo` and `project` s
 **Do not:**
 - Commit tokens to any repository — including instance config YAML files.
 - Log tokens or include them in bug reports.
-- Set tokens in shell history (use `read -s GHES_TOKEN` or equivalent).
+- Set tokens in shell history. To avoid this, use:
+  ```bash
+  read -rs GHES_TOKEN && export GHES_TOKEN
+  ```
 
 Instance config files (`*.yaml`) intentionally have no `token` field.
 The token is always supplied at runtime, never stored in YAML.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Token handling
+
+plynth requires a GitHub Personal Access Token (PAT) with `repo` and `project` scopes.
+
+**Do:**
+- Pass the token via the `GHES_TOKEN` environment variable.
+- Use `--token` for one-off invocations where environment variables are inconvenient.
+- Store tokens in a secrets management system, not in files on disk.
+- Rotate tokens regularly and revoke unused ones.
+
+**Do not:**
+- Commit tokens to any repository — including instance config YAML files.
+- Log tokens or include them in bug reports.
+- Set tokens in shell history (use `read -s GHES_TOKEN` or equivalent).
+
+Instance config files (`*.yaml`) intentionally have no `token` field.
+The token is always supplied at runtime, never stored in YAML.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in plynth, please report it privately
+rather than opening a public GitHub issue.
+
+**Contact:** open a [GitHub Security Advisory](https://github.com/Declaratus/plynth/security/advisories/new)
+or email the maintainer directly (address on the GitHub profile).
+
+Please include:
+- A description of the vulnerability and its impact.
+- Steps to reproduce or a minimal proof-of-concept.
+- Any suggested mitigation.
+
+We aim to acknowledge reports within 48 hours and to publish a fix within 14 days
+for confirmed critical issues.
+
+## Supported versions
+
+Only the latest release receives security fixes.
+Pin to a specific release tag in production and update promptly when a security
+fix is published.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,17 @@ dependencies = [
     "requests>=2.28",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7",
+    "pytest-mock>=3",
+    "responses>=0.24",
+    "ruff>=0.5",
+    "mypy>=1.10",
+    "types-requests",
+    "types-PyYAML",
+]
+
 [project.urls]
 Homepage = "https://github.com/declaratus/plynth"
 Issues = "https://github.com/declaratus/plynth/issues"


### PR DESCRIPTION
## Summary

Adds the OSS project scaffolding layer: license, changelog, contributing guide, security policy, and GitHub issue/PR templates. No code changes — all new files.

## Changes

- `LICENSE` — Apache 2.0, copyright Barry Johnston
- `CHANGELOG.md` — Keep-a-Changelog format; `[Unreleased]` section seeded + retroactive `[0.1.0]` entry covering the full initial feature set
- `CONTRIBUTING.md` — dev setup (`pip install -e ".[dev]"`), test/lint commands, commit format, PR flow, and authentication policy for tests (no live API calls in tests)
- `SECURITY.md` — token handling rules (use `GHES_TOKEN` env var; no `token` field in instance YAML), vulnerability reporting via GitHub Security Advisories
- `.github/ISSUE_TEMPLATE/bug_report.md` — environment, reproduction steps, config snippets, state file section
- `.github/ISSUE_TEMPLATE/feature_request.md` — motivation, proposed behaviour with schema example, alternatives
- `.github/PULL_REQUEST_TEMPLATE.md` — testing checklist, quality gates (ruff, mypy, CHANGELOG update, no credentials)

## Testing

- [ ] No testable behaviour change (new files only)

## Checklist

- [x] No tokens, credentials, or org-specific names committed
- [x] `CHANGELOG.md` updated under `## [Unreleased]`