### PR TITLE
PR 2: Lint, format, and type-check config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - CONTRIBUTING.md
 - SECURITY.md
 - GitHub issue and PR templates (`.github/`)
+- Ruff lint + format configuration (`[tool.ruff]`).
+- Mypy strict type-check configuration (`[tool.mypy]`).
+- Pytest configuration (`[tool.pytest.ini_options]`).
+- PEP 561 marker (`plynth/py.typed`) so downstream consumers see plynth's types.
+
+### Changed
+- Codebase reformatted with `ruff format`.
+- `plynth/models/instance.py` — `start_date` validator now chains the underlying
+  `ValueError` with `raise ... from e` (B904).
+
+### Removed
+- Dead no-op loop in `plynth/engine/planner.py` dry-run formatter.
 
 ---
 
@@ -50,7 +62,7 @@ Initial release. Core engine complete and functional against GHES 3.19.
   `--dry-run`, `--token`, `--state-dir`, `--write-delay-ms`, `--verbose`.
 - **GraphQL query/mutation strings** (`plynth/queries/`) — all mutations and
   queries as module-level constants.
-- **Sanitized agent-reference docs** (`docs/`) — design spec, orchestrator spec,
+- **agent-reference docs** (`docs/`) — design spec, orchestrator spec,
   planner spec, API client spec, example template (17 issues, 5 milestones),
   and example instance config.
 

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -32,61 +32,36 @@ from plynth.models.template import TemplateDefinition
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="plynth",
-        description=(
-            "GitHub Projects as Code -- bootstrap GitHub Projects "
-            "from YAML templates."
-        ),
+        description=("GitHub Projects as Code -- bootstrap GitHub Projects from YAML templates."),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # --- create command ---
-    create_parser = subparsers.add_parser(
-        "create", help="Create a new project from template"
-    )
-    create_parser.add_argument(
-        "--template", required=True, help="Path to template YAML"
-    )
-    create_parser.add_argument(
-        "--instance", required=True, help="Path to instance config YAML"
-    )
+    create_parser = subparsers.add_parser("create", help="Create a new project from template")
+    create_parser.add_argument("--template", required=True, help="Path to template YAML")
+    create_parser.add_argument("--instance", required=True, help="Path to instance config YAML")
     create_parser.add_argument(
         "--dry-run", action="store_true", help="Print plan without executing"
     )
-    create_parser.add_argument(
-        "--token", help="GHES PAT (or set GHES_TOKEN env var)"
-    )
-    create_parser.add_argument(
-        "--state-dir", default=".", help="Directory for state file output"
-    )
+    create_parser.add_argument("--token", help="GHES PAT (or set GHES_TOKEN env var)")
+    create_parser.add_argument("--state-dir", default=".", help="Directory for state file output")
     create_parser.add_argument(
         "--write-delay-ms",
         type=int,
         default=1000,
         help="Delay between API writes (ms)",
     )
-    create_parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Verbose logging"
-    )
+    create_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
 
     # --- resolve command ---
     resolve_parser = subparsers.add_parser(
         "resolve", help="Re-resolve cross-references from state file"
     )
-    resolve_parser.add_argument(
-        "--state", required=True, help="Path to existing state file"
-    )
-    resolve_parser.add_argument(
-        "--template", required=True, help="Path to template YAML"
-    )
-    resolve_parser.add_argument(
-        "--instance", required=True, help="Path to instance config YAML"
-    )
-    resolve_parser.add_argument(
-        "--token", help="GHES PAT (or set GHES_TOKEN env var)"
-    )
-    resolve_parser.add_argument(
-        "-v", "--verbose", action="store_true"
-    )
+    resolve_parser.add_argument("--state", required=True, help="Path to existing state file")
+    resolve_parser.add_argument("--template", required=True, help="Path to template YAML")
+    resolve_parser.add_argument("--instance", required=True, help="Path to instance config YAML")
+    resolve_parser.add_argument("--token", help="GHES PAT (or set GHES_TOKEN env var)")
+    resolve_parser.add_argument("-v", "--verbose", action="store_true")
 
     args = parser.parse_args()
 
@@ -122,20 +97,13 @@ def _cmd_create(args: argparse.Namespace, log: logging.Logger) -> None:
     token = _get_token(args)
 
     # 5. Initialize clients
-    base = GHESClient(
-        instance.ghes_url, token, write_delay_ms=args.write_delay_ms
-    )
+    base = GHESClient(instance.ghes_url, token, write_delay_ms=args.write_delay_ms)
     gql = GraphQLClient(base)
     rest = RESTClient(base)
 
     # 6. Initialize or resume state file
-    state_path = (
-        Path(args.state_dir)
-        / f"{_slugify(execution_plan.project_name)}.plynth-state.yaml"
-    )
-    state = _init_or_load_state(
-        state_path, args.template, args.instance, instance, log
-    )
+    state_path = Path(args.state_dir) / f"{_slugify(execution_plan.project_name)}.plynth-state.yaml"
+    state = _init_or_load_state(state_path, args.template, args.instance, instance, log)
 
     # 7. Execute
     orchestrator = PhaseOrchestrator(

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -98,9 +98,7 @@ class PhaseOrchestrator:
 
         # 1a. Resolve org and repo IDs
         org_id = self.gql.get_org_id(self.plan.instance_org)
-        repo_id = self.gql.get_repo_id(
-            self.plan.instance_org, self.plan.instance_repo
-        )
+        repo_id = self.gql.get_repo_id(self.plan.instance_org, self.plan.instance_repo)
         self.state.repo = RepoState(name=self.plan.instance_repo, node_id=repo_id)
 
         # 1b. Create the project
@@ -110,16 +108,13 @@ class PhaseOrchestrator:
             url=project["url"],
             number=project["number"],
         )
-        self.log.info(
-            f"Created project: {self.plan.project_name} ({project['url']})"
-        )
+        self.log.info(f"Created project: {self.plan.project_name} ({project['url']})")
 
         # 1c. Create custom fields
         for field in self.plan.fields:
             if field.type == "single_select":
                 options = [
-                    {"name": opt, "color": "GRAY", "description": ""}
-                    for opt in field.options
+                    {"name": opt, "color": "GRAY", "description": ""} for opt in field.options
                 ]
                 self.gql.create_field(
                     project_id=self.state.project.node_id,
@@ -127,9 +122,7 @@ class PhaseOrchestrator:
                     data_type="SINGLE_SELECT",
                     options=options,
                 )
-                self.log.info(
-                    f"Created field: {field.name} ({len(field.options)} options)"
-                )
+                self.log.info(f"Created field: {field.name} ({len(field.options)} options)")
 
         # 1d. Re-query to get actual field IDs and option IDs
         raw_fields = self.gql.get_project_fields(self.state.project.node_id)
@@ -155,9 +148,7 @@ class PhaseOrchestrator:
                 for opt in raw["options"]:
                     options_map[opt["name"]] = opt["id"]
 
-            self.state.fields[field_def.id] = FieldState(
-                node_id=raw["id"], options=options_map
-            )
+            self.state.fields[field_def.id] = FieldState(node_id=raw["id"], options=options_map)
 
     # ── Phase 2: Create Milestones ─────────────────────────
 
@@ -181,9 +172,7 @@ class PhaseOrchestrator:
                 node_id=result["node_id"],
                 title=result["title"],
             )
-            self.log.info(
-                f"Created milestone: {ms.title} (#{result['number']})"
-            )
+            self.log.info(f"Created milestone: {ms.title} (#{result['number']})")
 
     # ── Phase 3: Create Issues ─────────────────────────────
 
@@ -192,9 +181,7 @@ class PhaseOrchestrator:
         for issue in self.plan.issues:
             milestone_node_id = None
             if issue.milestone_id in self.state.milestones:
-                milestone_node_id = self.state.milestones[
-                    issue.milestone_id
-                ].node_id
+                milestone_node_id = self.state.milestones[issue.milestone_id].node_id
 
             result = self.gql.create_issue(
                 repository_id=self.state.repo.node_id,
@@ -243,10 +230,7 @@ class PhaseOrchestrator:
             # 4c. Set custom field values
             for field_key, option_display_value in issue.fields.items():
                 if field_key not in self.state.fields:
-                    self.log.warning(
-                        f"Field '{field_key}' not found in project fields, "
-                        f"skipping"
-                    )
+                    self.log.warning(f"Field '{field_key}' not found in project fields, skipping")
                     continue
 
                 field_state = self.state.fields[field_key]
@@ -267,8 +251,7 @@ class PhaseOrchestrator:
                 )
 
             self.log.info(
-                f"Added #{issue_state.number} to project and set "
-                f"{len(issue.fields)} field values"
+                f"Added #{issue_state.number} to project and set {len(issue.fields)} field values"
             )
 
     # ── Phase 5: Resolve Cross-References + Dependencies ───
@@ -296,9 +279,7 @@ class PhaseOrchestrator:
 
             if resolved_body != issue.body:
                 self.gql.update_issue_body(issue_state.node_id, resolved_body)
-                issue_state.body_sha256 = hashlib.sha256(
-                    resolved_body.encode()
-                ).hexdigest()
+                issue_state.body_sha256 = hashlib.sha256(resolved_body.encode()).hexdigest()
                 self.log.info(f"Resolved cross-refs in #{issue_state.number}")
 
         # 5c. Wire dependency edges via addBlockedBy
@@ -321,9 +302,7 @@ class PhaseOrchestrator:
                     blocking_issue_id=blocker_state.node_id,
                 )
                 self.state.dependencies_created.append(
-                    DependencyEdge(
-                        blocker=blocker_id, blocked=issue.template_id
-                    )
+                    DependencyEdge(blocker=blocker_id, blocked=issue.template_id)
                 )
 
             # blocks: target is blocked by this issue
@@ -333,9 +312,7 @@ class PhaseOrchestrator:
                 blocked_state = self.state.issues[blocked_id]
 
                 # Deduplicate: skip if already created from the other direction
-                edge = DependencyEdge(
-                    blocker=issue.template_id, blocked=blocked_id
-                )
+                edge = DependencyEdge(blocker=issue.template_id, blocked=blocked_id)
                 if edge not in self.state.dependencies_created:
                     self.gql.add_blocked_by(
                         issue_id=blocked_state.node_id,
@@ -345,10 +322,7 @@ class PhaseOrchestrator:
 
             dep_count = len(issue.blocked_by) + len(issue.blocks)
             if dep_count > 0:
-                self.log.info(
-                    f"Wired {dep_count} dependencies for "
-                    f"#{issue_state.number}"
-                )
+                self.log.info(f"Wired {dep_count} dependencies for #{issue_state.number}")
 
     def _build_skipped_ref_set(self, issue: ResolvedIssue) -> set[str]:
         """Build set of {PREFIX}-### strings for skipped dependencies."""

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -47,18 +47,14 @@ def resolve_placeholders(
     return text
 
 
-def _calculate_due_date(
-    start_date_str: str | None, offset_weeks: int
-) -> str | None:
+def _calculate_due_date(start_date_str: str | None, offset_weeks: int) -> str | None:
     if start_date_str is None:
         return None
     start = date.fromisoformat(start_date_str)
     return (start + timedelta(weeks=offset_weeks)).isoformat()
 
 
-def plan(
-    template: TemplateDefinition, instance: InstanceConfig
-) -> ExecutionPlan:
+def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPlan:
     """Build a fully resolved execution plan from template + instance config.
 
     Pure computation — no API calls. Validates placeholder coverage, computes
@@ -75,9 +71,7 @@ def plan(
         if spec.required and (key not in values or not values[key])
     ]
     if missing:
-        raise ValueError(
-            f"Missing required placeholder values: {', '.join(sorted(missing))}"
-        )
+        raise ValueError(f"Missing required placeholder values: {', '.join(sorted(missing))}")
 
     # ── Step 2: Effective milestones ───────────────────────────────
     skip_ms = set(instance.skip_milestones)
@@ -93,11 +87,7 @@ def plan(
     ]
 
     # ── Step 3: Effective issues ───────────────────────────────────
-    skipped_by_milestone = {
-        i.template_id
-        for i in template.issues
-        if i.milestone_id in skip_ms
-    }
+    skipped_by_milestone = {i.template_id for i in template.issues if i.milestone_id in skip_ms}
     skipped_individually = set(instance.skip_issues)
 
     skipped_by_pruning: set[str] = set()
@@ -111,9 +101,7 @@ def plan(
                     break
 
     all_skipped = skipped_by_milestone | skipped_individually | skipped_by_pruning
-    effective_issues = [
-        i for i in template.issues if i.template_id not in all_skipped
-    ]
+    effective_issues = [i for i in template.issues if i.template_id not in all_skipped]
     valid_ids = {i.template_id for i in effective_issues}
 
     # ── Step 4 & 5: Resolve placeholders + trim deps ──────────────
@@ -125,9 +113,7 @@ def plan(
             fields.update(instance.field_overrides[issue.template_id])
 
         # Resolve placeholders in field option values
-        resolved_fields = {
-            k: resolve_placeholders(v, values) for k, v in fields.items()
-        }
+        resolved_fields = {k: resolve_placeholders(v, values) for k, v in fields.items()}
 
         # Trim dependency graph
         good_bb: list[str] = []
@@ -149,17 +135,13 @@ def plan(
                 good_bl.append(ref)
             else:
                 skip_bl.append(ref)
-                warnings.append(
-                    f"Issue {issue.template_id}: blocks ref '{ref}' was skipped"
-                )
+                warnings.append(f"Issue {issue.template_id}: blocks ref '{ref}' was skipped")
 
         resolved_issues.append(
             ResolvedIssue(
                 template_id=issue.template_id,
                 title=resolve_placeholders(issue.title, values),
-                body=resolve_placeholders(
-                    issue.body, values, preserve_crossrefs=True
-                ),
+                body=resolve_placeholders(issue.body, values, preserve_crossrefs=True),
                 milestone_id=issue.milestone_id,
                 fields=resolved_fields,
                 blocked_by=good_bb,
@@ -181,9 +163,7 @@ def plan(
     ]
 
     # ── Step 8: Resolve project description ({DATE}) ──────────────
-    project_desc = instance.project.description.replace(
-        "{DATE}", date.today().isoformat()
-    )
+    project_desc = instance.project.description.replace("{DATE}", date.today().isoformat())
 
     # ── Step 9: Assemble ───────────────────────────────────────────
     return ExecutionPlan(
@@ -206,9 +186,7 @@ def plan(
     )
 
 
-def all_skipped_milestones(
-    skip_ms: set[str], template: TemplateDefinition
-) -> list[str]:
+def all_skipped_milestones(skip_ms: set[str], template: TemplateDefinition) -> list[str]:
     """Return milestone IDs that were actually skipped (exist in template)."""
     return [m.id for m in template.milestones if m.id in skip_ms]
 
@@ -237,10 +215,7 @@ def format_dry_run(ep: ExecutionPlan) -> str:
     if ep.skipped_milestones:
         w(f"Skipped milestones: {', '.join(ep.skipped_milestones)}")
     if ep.skipped_issues:
-        w(
-            f"Skipped issues ({len(ep.skipped_issues)}): "
-            f"{', '.join(ep.skipped_issues)}"
-        )
+        w(f"Skipped issues ({len(ep.skipped_issues)}): {', '.join(ep.skipped_issues)}")
     if ep.skipped_milestones or ep.skipped_issues:
         w("")
 
@@ -268,9 +243,6 @@ def format_dry_run(ep: ExecutionPlan) -> str:
     w(f"Fields ({len(ep.fields)}):")
     for f in ep.fields:
         w(f"  {f.id}: {f.name} [{f.type}] ({len(f.options)} options)")
-        # Show any options that had placeholders resolved
-        for orig_f in ep.fields:
-            pass  # options are already resolved
     w("")
 
     # Warnings
@@ -287,14 +259,7 @@ def format_dry_run(ep: ExecutionPlan) -> str:
     n_deps = sum(len(i.blocked_by) for i in ep.issues)
     n_body_updates = n_issues
     n_add_to_project = n_issues
-    total = (
-        n_milestones
-        + n_issues
-        + n_add_to_project
-        + n_field_values
-        + n_body_updates
-        + n_deps
-    )
+    total = n_milestones + n_issues + n_add_to_project + n_field_values + n_body_updates + n_deps
 
     w("API call estimate:")
     w(f"  Milestones:     {n_milestones} REST calls")

--- a/plynth/models/instance.py
+++ b/plynth/models/instance.py
@@ -45,8 +45,6 @@ class InstanceConfig(BaseModel):
         if v is not None:
             try:
                 date.fromisoformat(v)
-            except ValueError:
-                raise ValueError(
-                    f"start_date must be YYYY-MM-DD format, got '{v}'"
-                )
+            except ValueError as e:
+                raise ValueError(f"start_date must be YYYY-MM-DD format, got '{v}'") from e
         return v

--- a/plynth/models/state.py
+++ b/plynth/models/state.py
@@ -119,9 +119,7 @@ class StateFile(BaseModel):
         self.updated_at = self._now_iso()
 
     def mark_phase_complete(self, phase: str) -> None:
-        self.phases[phase] = PhaseStatus(
-            completed=True, completed_at=self._now_iso()
-        )
+        self.phases[phase] = PhaseStatus(completed=True, completed_at=self._now_iso())
         self.touch()
 
     def mark_phase_error(self, phase: str, error: str) -> None:

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -135,45 +135,35 @@ class TemplateDefinition(BaseModel):
             for ref in issue.blocked_by:
                 if ref not in template_ids:
                     errors.append(
-                        f"Issue {issue.template_id}: blocked_by ref "
-                        f"'{ref}' not found in issues"
+                        f"Issue {issue.template_id}: blocked_by ref '{ref}' not found in issues"
                     )
 
             for ref in issue.blocks:
                 if ref not in template_ids:
                     errors.append(
-                        f"Issue {issue.template_id}: blocks ref "
-                        f"'{ref}' not found in issues"
+                        f"Issue {issue.template_id}: blocks ref '{ref}' not found in issues"
                     )
 
             for field_key in issue.fields:
                 if field_key not in field_ids:
                     errors.append(
-                        f"Issue {issue.template_id}: field key "
-                        f"'{field_key}' not found in fields"
+                        f"Issue {issue.template_id}: field key '{field_key}' not found in fields"
                     )
 
         if self.pruning:
             if self.pruning.trigger_issue not in template_ids:
                 errors.append(
-                    f"Pruning trigger_issue '{self.pruning.trigger_issue}' "
-                    f"not found in issues"
+                    f"Pruning trigger_issue '{self.pruning.trigger_issue}' not found in issues"
                 )
             for rule in self.pruning.rules:
                 for ref in rule.keep_issues:
                     if ref not in template_ids:
-                        errors.append(
-                            f"Pruning keep_issues ref '{ref}' not found in issues"
-                        )
+                        errors.append(f"Pruning keep_issues ref '{ref}' not found in issues")
                 for ref in rule.remove_issues:
                     if ref not in template_ids:
-                        errors.append(
-                            f"Pruning remove_issues ref '{ref}' not found in issues"
-                        )
+                        errors.append(f"Pruning remove_issues ref '{ref}' not found in issues")
 
         if errors:
-            raise ValueError(
-                "Template reference validation failed:\n  " + "\n  ".join(errors)
-            )
+            raise ValueError("Template reference validation failed:\n  " + "\n  ".join(errors))
 
         return self

--- a/plynth/utils/references.py
+++ b/plynth/utils/references.py
@@ -26,11 +26,7 @@ def resolve_crossrefs(
 
     # Sort longest first to avoid partial matches
     sorted_refs = sorted(all_refs, key=len, reverse=True)
-    pattern = re.compile(
-        r"(?<!\w)("
-        + "|".join(re.escape(ref) for ref in sorted_refs)
-        + r")(?!\w)"
-    )
+    pattern = re.compile(r"(?<!\w)(" + "|".join(re.escape(ref) for ref in sorted_refs) + r")(?!\w)")
 
     def _replace(match: re.Match[str]) -> str:
         ref = match.group(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,39 @@ Issues = "https://github.com/declaratus/plynth/issues"
 
 [project.scripts]
 plynth = "plynth.cli:main"
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+"plynth/queries/*.py" = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+pretty = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["yaml", "responses"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["plynth.engine.graphql_client", "plynth.engine.rest_client"]
+disable_error_code = ["type-arg", "no-any-return"]
+
+[[tool.mypy.overrides]]
+module = ["plynth.engine.phases"]
+disable_error_code = ["union-attr"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"


### PR DESCRIPTION
## Summary
- Add ruff lint+format, mypy strict, and pytest configuration to `pyproject.toml`.
- Add `plynth/py.typed` (PEP 561) so consumers see plynth's types.
- Reformat the codebase with `ruff format` and fix one B904 violation.
- Remove a dead no-op loop in the planner dry-run formatter (caught during exploration).

## Notes
Per the maturity plan, mypy strict is narrowed via per-module overrides for
`engine.graphql_client`, `engine.rest_client`, and `engine.phases` rather than
expanding scope into a refactor. Future PRs (e.g. PR 5 error handling) will
naturally tighten these as the engine modules are touched.

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy plynth` clean (19 files, strict mode)
- [ ] CI gates green (added in PR 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)