### PR TITLE
PR 3: Unit test foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- Unit test foundation under `tests/`: shared fixtures
+  (`tests/fixtures/minimal-template.yaml`, `tests/fixtures/minimal-instance.yaml`),
+  conftest, and tests for `models.template`, `models.instance`, `models.state`,
+  `engine.planner`, `utils.references`, and CLI argument parsing
+  (41 tests, ~0.1s).
+
+### Added (PR 2)
 - LICENSE (Apache 2.0)
 - CHANGELOG.md
 - CONTRIBUTING.md

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -29,7 +29,8 @@ from plynth.models.state import (
 from plynth.models.template import TemplateDefinition
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Build the plynth argparse parser. Exposed for test reuse."""
     parser = argparse.ArgumentParser(
         prog="plynth",
         description=("GitHub Projects as Code -- bootstrap GitHub Projects from YAML templates."),
@@ -63,6 +64,11 @@ def main() -> None:
     resolve_parser.add_argument("--token", help="GHES PAT (or set GHES_TOKEN env var)")
     resolve_parser.add_argument("-v", "--verbose", action="store_true")
 
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     # Configure logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from plynth.models.instance import InstanceConfig
+from plynth.models.template import TemplateDefinition
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def minimal_template_path() -> Path:
+    return FIXTURES_DIR / "minimal-template.yaml"
+
+
+@pytest.fixture
+def minimal_instance_path() -> Path:
+    return FIXTURES_DIR / "minimal-instance.yaml"
+
+
+@pytest.fixture
+def minimal_template(minimal_template_path: Path) -> TemplateDefinition:
+    with open(minimal_template_path, encoding="utf-8") as f:
+        return TemplateDefinition.model_validate(yaml.safe_load(f))
+
+
+@pytest.fixture
+def minimal_instance(minimal_instance_path: Path) -> InstanceConfig:
+    with open(minimal_instance_path, encoding="utf-8") as f:
+        return InstanceConfig.model_validate(yaml.safe_load(f))

--- a/tests/fixtures/minimal-instance.yaml
+++ b/tests/fixtures/minimal-instance.yaml
@@ -1,0 +1,19 @@
+template: "minimal-template.yaml"
+ghes_url: "https://ghes.example.com/"
+org: "example-org"
+
+values:
+  APP: "Acme"
+  PREFIX: "ACME"
+  TEAM: "Platform"
+
+repo:
+  name: "acme"
+
+project:
+  name: "Acme Bootstrap"
+  description: "Minimal project for tests ({DATE})."
+
+start_date: "2026-05-01"
+skip_milestones: []
+skip_issues: []

--- a/tests/fixtures/minimal-template.yaml
+++ b/tests/fixtures/minimal-template.yaml
@@ -1,0 +1,60 @@
+schema_version: "1.0"
+
+template:
+  name: "Minimal Test Template"
+  description: "Smallest viable template for unit tests."
+  version: "0.0.1"
+
+placeholders:
+  APP:
+    description: "Application name."
+    example: "Acme"
+    required: true
+  PREFIX:
+    description: "Cross-reference prefix."
+    example: "ACME"
+    required: true
+  TEAM:
+    description: "Owning team."
+    example: "Platform"
+    required: false
+
+status:
+  - {value: "Todo", color: "GRAY"}
+  - {value: "Done", color: "GREEN"}
+
+fields:
+  - id: priority
+    name: "Priority"
+    type: single_select
+    options: ["P1", "P2", "{TEAM}"]
+
+milestones:
+  - id: M1
+    title: "{APP} Foundation"
+    description: "First milestone for {APP}."
+    due_offset_weeks: 2
+  - id: M2
+    title: "{APP} Hardening"
+    description: "Second milestone."
+    due_offset_weeks: 4
+    optional: true
+
+issues:
+  - template_id: "{PREFIX}-001"
+    title: "Bootstrap {APP}"
+    milestone_id: M1
+    fields: {priority: "P1"}
+    body: "Set up initial scaffolding for {APP}."
+  - template_id: "{PREFIX}-002"
+    title: "Configure {APP}"
+    milestone_id: M1
+    fields: {priority: "P2"}
+    blocked_by: ["{PREFIX}-001"]
+    body: "Depends on {PREFIX}-001 completing."
+  - template_id: "{PREFIX}-003"
+    title: "Harden {APP}"
+    milestone_id: M2
+    fields: {priority: "{TEAM}"}
+    blocked_by: ["{PREFIX}-002"]
+    body: "Final hardening of {APP}."

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -2,36 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-
-def _build_parser():
-    # Reconstruct the parser without invoking main(). We mirror cli.main()'s
-    # argument layout; if cli.main() is restructured, this test guides the change.
-    import argparse
-
-    parser = argparse.ArgumentParser(prog="plynth")
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    create = sub.add_parser("create")
-    create.add_argument("--template", required=True)
-    create.add_argument("--instance", required=True)
-    create.add_argument("--dry-run", action="store_true")
-    create.add_argument("--token")
-    create.add_argument("--state-dir", default=".")
-    create.add_argument("--write-delay-ms", type=int, default=1000)
-    create.add_argument("-v", "--verbose", action="store_true")
-
-    resolve = sub.add_parser("resolve")
-    resolve.add_argument("--state", required=True)
-    resolve.add_argument("--template", required=True)
-    resolve.add_argument("--instance", required=True)
-    resolve.add_argument("--token")
-    resolve.add_argument("-v", "--verbose", action="store_true")
-
-    return parser
+from plynth.cli import build_parser
 
 
 def test_create_command_parses() -> None:
-    parser = _build_parser()
+    parser = build_parser()
     ns = parser.parse_args(["create", "--template", "t.yaml", "--instance", "i.yaml", "--dry-run"])
     assert ns.command == "create"
     assert ns.template == "t.yaml"
@@ -42,13 +17,13 @@ def test_create_command_parses() -> None:
 
 
 def test_create_requires_template_and_instance() -> None:
-    parser = _build_parser()
+    parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["create"])
 
 
 def test_resolve_command_parses() -> None:
-    parser = _build_parser()
+    parser = build_parser()
     ns = parser.parse_args(
         [
             "resolve",
@@ -65,6 +40,6 @@ def test_resolve_command_parses() -> None:
 
 
 def test_unknown_subcommand_rejected() -> None:
-    parser = _build_parser()
+    parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["bogus"])

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _build_parser():
+    # Reconstruct the parser without invoking main(). We mirror cli.main()'s
+    # argument layout; if cli.main() is restructured, this test guides the change.
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="plynth")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create")
+    create.add_argument("--template", required=True)
+    create.add_argument("--instance", required=True)
+    create.add_argument("--dry-run", action="store_true")
+    create.add_argument("--token")
+    create.add_argument("--state-dir", default=".")
+    create.add_argument("--write-delay-ms", type=int, default=1000)
+    create.add_argument("-v", "--verbose", action="store_true")
+
+    resolve = sub.add_parser("resolve")
+    resolve.add_argument("--state", required=True)
+    resolve.add_argument("--template", required=True)
+    resolve.add_argument("--instance", required=True)
+    resolve.add_argument("--token")
+    resolve.add_argument("-v", "--verbose", action="store_true")
+
+    return parser
+
+
+def test_create_command_parses() -> None:
+    parser = _build_parser()
+    ns = parser.parse_args(["create", "--template", "t.yaml", "--instance", "i.yaml", "--dry-run"])
+    assert ns.command == "create"
+    assert ns.template == "t.yaml"
+    assert ns.instance == "i.yaml"
+    assert ns.dry_run is True
+    assert ns.write_delay_ms == 1000
+    assert ns.state_dir == "."
+
+
+def test_create_requires_template_and_instance() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["create"])
+
+
+def test_resolve_command_parses() -> None:
+    parser = _build_parser()
+    ns = parser.parse_args(
+        [
+            "resolve",
+            "--state",
+            "s.yaml",
+            "--template",
+            "t.yaml",
+            "--instance",
+            "i.yaml",
+        ]
+    )
+    assert ns.command == "resolve"
+    assert ns.state == "s.yaml"
+
+
+def test_unknown_subcommand_rejected() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["bogus"])

--- a/tests/test_models_instance.py
+++ b/tests/test_models_instance.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from plynth.models.instance import InstanceConfig
+
+
+def _base_instance_dict() -> dict:
+    return {
+        "template": "t.yaml",
+        "ghes_url": "https://ghes.example.com",
+        "org": "example-org",
+        "values": {"APP": "Acme"},
+        "repo": {"name": "acme"},
+        "project": {"name": "Acme"},
+    }
+
+
+def test_ghes_url_trailing_slash_stripped() -> None:
+    data = _base_instance_dict()
+    data["ghes_url"] = "https://ghes.example.com/"
+    cfg = InstanceConfig.model_validate(data)
+    assert cfg.ghes_url == "https://ghes.example.com"
+
+
+def test_ghes_url_multi_trailing_slash_stripped() -> None:
+    data = _base_instance_dict()
+    data["ghes_url"] = "https://ghes.example.com///"
+    cfg = InstanceConfig.model_validate(data)
+    assert cfg.ghes_url == "https://ghes.example.com"
+
+
+def test_start_date_valid_iso() -> None:
+    data = _base_instance_dict()
+    data["start_date"] = "2026-05-01"
+    cfg = InstanceConfig.model_validate(data)
+    assert cfg.start_date == "2026-05-01"
+
+
+def test_start_date_none_allowed() -> None:
+    cfg = InstanceConfig.model_validate(_base_instance_dict())
+    assert cfg.start_date is None
+
+
+def test_start_date_bad_format_rejected() -> None:
+    data = _base_instance_dict()
+    data["start_date"] = "05/01/2026"
+    with pytest.raises(ValidationError, match="start_date must be YYYY-MM-DD"):
+        InstanceConfig.model_validate(data)
+
+
+def test_extra_keys_rejected() -> None:
+    data = _base_instance_dict()
+    data["bogus"] = "x"
+    with pytest.raises(ValidationError):
+        InstanceConfig.model_validate(data)
+
+
+def test_defaults() -> None:
+    cfg = InstanceConfig.model_validate(_base_instance_dict())
+    assert cfg.skip_milestones == []
+    assert cfg.skip_issues == []
+    assert cfg.field_overrides == {}
+    assert cfg.pruning_decision is None
+    assert cfg.repo.create is False

--- a/tests/test_models_state.py
+++ b/tests/test_models_state.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from plynth.models.state import (
+    PHASE_1_PROJECT_AND_FIELDS,
+    PHASE_3_ISSUES,
+    StateFile,
+)
+
+
+def test_default_schema_version() -> None:
+    s = StateFile()
+    assert s.schema_version == "1.0"
+
+
+def test_phase_complete_helpers() -> None:
+    s = StateFile()
+    assert not s.is_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+
+    s.mark_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+    assert s.is_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+    assert s.phases[PHASE_1_PROJECT_AND_FIELDS].completed_at is not None
+    assert s.phases[PHASE_1_PROJECT_AND_FIELDS].error is None
+
+
+def test_phase_error_recorded() -> None:
+    s = StateFile()
+    s.mark_phase_error(PHASE_3_ISSUES, "boom")
+    assert s.phases[PHASE_3_ISSUES].error == "boom"
+    assert s.phases[PHASE_3_ISSUES].completed is False
+    assert not s.is_phase_complete(PHASE_3_ISSUES)
+
+
+def test_touch_updates_timestamp() -> None:
+    s = StateFile()
+    assert s.updated_at == ""
+    s.touch()
+    assert s.updated_at != ""
+
+
+def test_roundtrip_through_model_dump() -> None:
+    s = StateFile(org="example-org", ghes_url="https://ghes.example.com")
+    s.mark_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+    dumped = s.model_dump()
+    rebuilt = StateFile.model_validate(dumped)
+    assert rebuilt.org == "example-org"
+    assert rebuilt.is_phase_complete(PHASE_1_PROJECT_AND_FIELDS)

--- a/tests/test_models_template.py
+++ b/tests/test_models_template.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from plynth.models.template import TemplateDefinition
+
+
+def _base_template_dict() -> dict:
+    return {
+        "schema_version": "1.0",
+        "template": {"name": "T", "description": "d", "version": "0.0.1"},
+        "placeholders": {},
+        "status": [{"value": "Todo", "color": "GRAY"}],
+        "fields": [
+            {"id": "priority", "name": "Priority", "type": "single_select", "options": ["P1"]}
+        ],
+        "milestones": [{"id": "M1", "title": "First", "description": "", "due_offset_weeks": 1}],
+        "issues": [
+            {
+                "template_id": "T-001",
+                "title": "i1",
+                "milestone_id": "M1",
+                "fields": {"priority": "P1"},
+            }
+        ],
+    }
+
+
+def test_minimal_template_loads(minimal_template: TemplateDefinition) -> None:
+    assert minimal_template.template.name == "Minimal Test Template"
+    assert len(minimal_template.milestones) == 2
+    assert len(minimal_template.issues) == 3
+
+
+def test_unknown_milestone_id_rejected() -> None:
+    data = _base_template_dict()
+    data["issues"][0]["milestone_id"] = "DOES_NOT_EXIST"
+    with pytest.raises(ValidationError, match="milestone_id 'DOES_NOT_EXIST' not found"):
+        TemplateDefinition.model_validate(data)
+
+
+def test_unknown_blocked_by_rejected() -> None:
+    data = _base_template_dict()
+    data["issues"][0]["blocked_by"] = ["T-999"]
+    with pytest.raises(ValidationError, match="blocked_by ref 'T-999' not found"):
+        TemplateDefinition.model_validate(data)
+
+
+def test_unknown_field_key_rejected() -> None:
+    data = _base_template_dict()
+    data["issues"][0]["fields"] = {"bogus_field": "X"}
+    with pytest.raises(ValidationError, match="field key 'bogus_field' not found"):
+        TemplateDefinition.model_validate(data)
+
+
+def test_extra_keys_rejected() -> None:
+    data = _base_template_dict()
+    data["unknown_key"] = "oops"
+    with pytest.raises(ValidationError):
+        TemplateDefinition.model_validate(data)
+
+
+def test_invalid_status_color_rejected() -> None:
+    data = _base_template_dict()
+    data["status"][0]["color"] = "ORANGE"
+    with pytest.raises(ValidationError):
+        TemplateDefinition.model_validate(data)
+
+
+def test_pruning_unknown_trigger_rejected() -> None:
+    data = _base_template_dict()
+    data["pruning"] = {
+        "trigger_issue": "T-NOPE",
+        "decision_field": "priority",
+        "rules": [],
+    }
+    with pytest.raises(ValidationError, match="trigger_issue 'T-NOPE' not found"):
+        TemplateDefinition.model_validate(data)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from plynth.engine.planner import format_dry_run, plan, resolve_placeholders
+from plynth.models.instance import InstanceConfig
+from plynth.models.template import TemplateDefinition
+
+
+def test_resolve_placeholders_basic() -> None:
+    result = resolve_placeholders("Hello {APP}!", {"APP": "Acme"})
+    assert result == "Hello Acme!"
+
+
+def test_resolve_placeholders_preserves_crossrefs() -> None:
+    body = "See {PREFIX}-001 and {PREFIX}-002. App is {APP}."
+    result = resolve_placeholders(body, {"PREFIX": "ACME", "APP": "Acme"}, preserve_crossrefs=True)
+    assert "{PREFIX}-001" in result
+    assert "{PREFIX}-002" in result
+    assert "App is Acme." in result
+
+
+def test_resolve_placeholders_resolves_when_not_preserving() -> None:
+    body = "See {PREFIX}-001."
+    result = resolve_placeholders(body, {"PREFIX": "ACME"})
+    assert result == "See ACME-001."
+
+
+def test_plan_basic(minimal_template: TemplateDefinition, minimal_instance: InstanceConfig) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    assert ep.template_name == "Minimal Test Template"
+    assert ep.instance_org == "example-org"
+    assert ep.project_name == "Acme Bootstrap"
+    assert len(ep.milestones) == 2
+    assert len(ep.issues) == 3
+    assert ep.warnings == []
+
+
+def test_plan_resolves_placeholders_in_titles(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    titles = [i.title for i in ep.issues]
+    assert "Bootstrap Acme" in titles
+    assert all("{APP}" not in t for t in titles)
+    milestone_titles = [m.title for m in ep.milestones]
+    assert "Acme Foundation" in milestone_titles
+
+
+def test_plan_resolves_team_placeholder_in_field_options(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    priority = next(f for f in ep.fields if f.id == "priority")
+    assert "Platform" in priority.options
+    assert "{TEAM}" not in priority.options
+
+
+def test_plan_preserves_crossrefs_in_bodies(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    bodies = [i.body for i in ep.issues]
+    assert any("{PREFIX}-001" in b for b in bodies)
+
+
+def test_plan_milestone_due_date_math(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    m1 = next(m for m in ep.milestones if m.id == "M1")
+    m2 = next(m for m in ep.milestones if m.id == "M2")
+    # start_date 2026-05-01 + 2 weeks = 2026-05-15
+    assert m1.due_date == "2026-05-15"
+    # + 4 weeks = 2026-05-29
+    assert m2.due_date == "2026-05-29"
+
+
+def test_plan_skip_milestone_cascades(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_instance.skip_milestones = ["M2"]
+    ep = plan(minimal_template, minimal_instance)
+    assert [m.id for m in ep.milestones] == ["M1"]
+    # ACME-003 lives on M2 → should be skipped
+    issue_ids = [i.template_id for i in ep.issues]
+    assert "{PREFIX}-003" not in issue_ids
+    assert "{PREFIX}-001" in issue_ids
+    assert "{PREFIX}-002" in issue_ids
+
+
+def test_plan_skip_milestone_trims_dependencies(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_instance.skip_milestones = ["M1"]
+    ep = plan(minimal_template, minimal_instance)
+    # All deps should be trimmed since M1 is gone (ACME-001, ACME-002 removed)
+    only_issue = ep.issues[0]
+    assert only_issue.template_id == "{PREFIX}-003"
+    assert only_issue.blocked_by == []
+    # The skipped ref should be recorded
+    assert "{PREFIX}-002" in only_issue.skipped_blocked_by
+    assert ep.warnings, "Expected warnings about trimmed deps"
+
+
+def test_plan_missing_required_placeholder_raises(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_instance.values = {"PREFIX": "ACME"}  # APP missing
+    with pytest.raises(ValueError, match="Missing required placeholder"):
+        plan(minimal_template, minimal_instance)
+
+
+def test_format_dry_run_shape(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    output = format_dry_run(ep)
+    assert "plynth Execution Plan" in output
+    assert "Acme Bootstrap" in output
+    assert "Milestones" in output
+    assert "Issues" in output
+    assert "Fields" in output

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -26,9 +26,11 @@ def test_longest_first_avoids_partial_match() -> None:
     # {PREFIX}-1 must not greedily consume {PREFIX}-100.
     body = "{PREFIX}-100 and {PREFIX}-1"
     out = resolve_crossrefs(body, {"{PREFIX}-1": "#1", "{PREFIX}-100": "#100"})
-    assert "#100" in out
-    assert "#1" in out
-    assert "{PREFIX}-100" not in out
+    # Exact match: both refs must be resolved independently with no leftover
+    # {PREFIX}-… text. A weak `"#1" in out` would pass even if only #100
+    # were present (since "#1" is a substring of "#100"), so assert exact equality.
+    assert out == "#100 and #1"
+    assert "{PREFIX}" not in out
 
 
 def test_empty_maps_no_change() -> None:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from plynth.utils.references import resolve_crossrefs
+
+
+def test_basic_substitution() -> None:
+    body = "See {PREFIX}-001 and {PREFIX}-002."
+    out = resolve_crossrefs(body, {"{PREFIX}-001": "#47", "{PREFIX}-002": "#48"})
+    assert out == "See #47 and #48."
+
+
+def test_skipped_ref_strikethrough() -> None:
+    body = "See {PREFIX}-006."
+    out = resolve_crossrefs(body, {}, skipped_refs={"{PREFIX}-006"})
+    assert "~~{PREFIX}-006~~ (skipped)" in out
+
+
+def test_unknown_ref_passthrough() -> None:
+    body = "See {PREFIX}-999."
+    out = resolve_crossrefs(body, {"{PREFIX}-001": "#47"})
+    # {PREFIX}-999 is not in the map and not skipped — body is unchanged.
+    assert "{PREFIX}-999" in out
+
+
+def test_longest_first_avoids_partial_match() -> None:
+    # {PREFIX}-1 must not greedily consume {PREFIX}-100.
+    body = "{PREFIX}-100 and {PREFIX}-1"
+    out = resolve_crossrefs(body, {"{PREFIX}-1": "#1", "{PREFIX}-100": "#100"})
+    assert "#100" in out
+    assert "#1" in out
+    assert "{PREFIX}-100" not in out
+
+
+def test_empty_maps_no_change() -> None:
+    body = "Plain text without refs."
+    assert resolve_crossrefs(body, {}) == body
+
+
+def test_word_boundary_protected() -> None:
+    # An identifier-like context shouldn't match.
+    body = "X{PREFIX}-001Y is not a ref."
+    out = resolve_crossrefs(body, {"{PREFIX}-001": "#47"})
+    assert "#47" not in out


### PR DESCRIPTION
## Summary
- Add \`tests/\` tree covering pure-logic surface (models, planner, references, CLI args). No network.
- 41 tests, ~0.1s wall time.
- Shared fixtures: a 3-issue / 2-milestone / 1-field minimal template + matching instance.

## Coverage focus
- Pydantic reference validation (template) and validators (instance).
- Planner: placeholder resolution, crossref preservation, field-option resolution, milestone date math, skip-milestone cascade, dependency trimming, dry-run formatter shape.
- References: longest-first matching, strikethrough for skipped refs, word-boundary protection.
- CLI: argparse parsing only (no execution path).

End-to-end and HTTP-mocked tests are deferred to PR 4.

## Test plan
- [x] \`pytest -q\` → 41 passed
- [x] \`ruff check .\` clean
- [x] \`ruff format --check .\` clean
- [x] \`mypy plynth\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)