### PR TITLE
PR 4: HTTP-mocked integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- HTTP-mocked integration tests under `tests/`:
+  - `test_api_base.py` — write-delay enforcement, retry-after handling,
+    exponential backoff on 503.
+  - `test_graphql_client.py` — happy-path coverage for every mutation/query
+    plus `GraphQLError` on `errors[]` response and HTTP error passthrough.
+  - `test_rest_client.py` — milestone create happy + 422 error.
+  - `test_phases_e2e.py` — full Phase 1→7 happy path against an in-test
+    GraphQL dispatcher; asserts state file contents and that a second run
+    is a no-op (resume behavior).
+- Test fixture `template_id`s switched from `{PREFIX}-NNN` to bare `NNN` to
+  match production templates.
+
+### Added (PR 3)
 - Unit test foundation under `tests/`: shared fixtures
   (`tests/fixtures/minimal-template.yaml`, `tests/fixtures/minimal-instance.yaml`),
   conftest, and tests for `models.template`, `models.instance`, `models.state`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `test_graphql_client.py` — happy-path coverage for every mutation/query
     plus `GraphQLError` on `errors[]` response and HTTP error passthrough.
   - `test_rest_client.py` — milestone create happy + 422 error.
-  - `test_phases_e2e.py` — full Phase 1→7 happy path against an in-test
-    GraphQL dispatcher; asserts state file contents and that a second run
-    is a no-op (resume behavior).
+  - `test_phases_e2e.py` — orchestrator runs Phases 1, 2, 3, 4, 5, 7
+    (Phase 6 / views is intentionally skipped by the orchestrator) against
+    an in-test GraphQL dispatcher; asserts in-memory state, then reloads
+    the YAML state file and reasserts on-disk contents, then builds a
+    fresh orchestrator from the loaded state and confirms a second run
+    issues zero API calls (persisted resume path).
 - Test fixture `template_id`s switched from `{PREFIX}-NNN` to bare `NNN` to
   match production templates.
 

--- a/tests/fixtures/minimal-template.yaml
+++ b/tests/fixtures/minimal-template.yaml
@@ -41,20 +41,20 @@ milestones:
     optional: true
 
 issues:
-  - template_id: "{PREFIX}-001"
+  - template_id: "001"
     title: "Bootstrap {APP}"
     milestone_id: M1
     fields: {priority: "P1"}
     body: "Set up initial scaffolding for {APP}."
-  - template_id: "{PREFIX}-002"
+  - template_id: "002"
     title: "Configure {APP}"
     milestone_id: M1
     fields: {priority: "P2"}
-    blocked_by: ["{PREFIX}-001"]
+    blocked_by: ["001"]
     body: "Depends on {PREFIX}-001 completing."
-  - template_id: "{PREFIX}-003"
+  - template_id: "003"
     title: "Harden {APP}"
     milestone_id: M2
     fields: {priority: "{TEAM}"}
-    blocked_by: ["{PREFIX}-002"]
-    body: "Final hardening of {APP}."
+    blocked_by: ["002"]
+    body: "Final hardening of {APP}. After {PREFIX}-002."

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import responses
+
+from plynth.engine.api_base import GHESClient
+
+
+def test_auth_header_set() -> None:
+    client = GHESClient("https://ghes.example.com", "tok123", write_delay_ms=0)
+    assert client.session.headers["Authorization"] == "Bearer tok123"
+    assert client.session.headers["Accept"] == "application/json"
+
+
+def test_write_delay_enforced() -> None:
+    client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=500)
+    client._record_write()
+
+    with patch("plynth.engine.api_base.time") as mock_time:
+        # 100ms after the recorded write — 400ms remaining.
+        mock_time.time.return_value = client._last_write_time + 0.1
+        client._wait_for_write_delay()
+
+    # sleep called with positive remaining time
+    mock_time.sleep.assert_called_once()
+    slept_for = mock_time.sleep.call_args[0][0]
+    assert 0.39 <= slept_for <= 0.41
+
+
+def test_write_delay_not_enforced_when_elapsed() -> None:
+    client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=500)
+    client._record_write()
+
+    with patch("plynth.engine.api_base.time") as mock_time:
+        # 1s after the recorded write — already past the delay.
+        mock_time.time.return_value = client._last_write_time + 1.0
+        client._wait_for_write_delay()
+
+    mock_time.sleep.assert_not_called()
+
+
+def test_handle_retry_with_retry_after_header() -> None:
+    client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(
+            responses.GET,
+            "https://ghes.example.com/api/test",
+            status=429,
+            headers={"Retry-After": "0"},
+        )
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep") as mock_sleep:
+            should_retry = client._handle_retry(r, attempt=0)
+            mock_sleep.assert_called_once_with(0.0)
+        return should_retry
+
+    assert _do() is True
+
+
+def test_handle_retry_503_uses_exponential_backoff() -> None:
+    client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> None:
+        responses.add(responses.GET, "https://ghes.example.com/api/test", status=503)
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep") as mock_sleep:
+            assert client._handle_retry(r, attempt=2) is True
+            # 2 ** 2 = 4
+            mock_sleep.assert_called_once_with(4)
+
+    _do()
+
+
+def test_handle_retry_returns_false_on_200() -> None:
+    client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(responses.GET, "https://ghes.example.com/api/test", status=200)
+        r = client.session.get("https://ghes.example.com/api/test")
+        return client._handle_retry(r, attempt=0)
+
+    assert _do() is False

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+import responses
+
+from plynth.engine.api_base import GHESClient
+from plynth.engine.graphql_client import GraphQLClient, GraphQLError
+
+GHES_URL = "https://ghes.example.com"
+GRAPHQL_URL = f"{GHES_URL}/api/graphql"
+
+
+def _client() -> GraphQLClient:
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0)
+    return GraphQLClient(base)
+
+
+@responses.activate
+def test_get_org_id() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"organization": {"id": "O_kgDO123"}}},
+        status=200,
+    )
+    assert _client().get_org_id("example-org") == "O_kgDO123"
+
+
+@responses.activate
+def test_get_repo_id() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"repository": {"id": "R_kgDO456"}}},
+        status=200,
+    )
+    assert _client().get_repo_id("example-org", "acme") == "R_kgDO456"
+
+
+@responses.activate
+def test_create_project() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "createProjectV2": {
+                    "projectV2": {
+                        "id": "PVT_1",
+                        "number": 7,
+                        "url": f"{GHES_URL}/orgs/example-org/projects/7",
+                    }
+                }
+            }
+        },
+        status=200,
+    )
+    out = _client().create_project("O_1", "Acme")
+    assert out["id"] == "PVT_1"
+    assert out["number"] == 7
+
+
+@responses.activate
+def test_create_field_with_options() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "createProjectV2Field": {"projectV2Field": {"id": "PVTSSF_1", "name": "Priority"}}
+            }
+        },
+        status=200,
+    )
+    out = _client().create_field("PVT_1", "Priority", "SINGLE_SELECT", options=[{"name": "P1"}])
+    assert out["id"] == "PVTSSF_1"
+
+
+@responses.activate
+def test_get_project_fields() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "node": {
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "PVTSSF_1",
+                                "name": "Priority",
+                                "options": [{"id": "opt_1", "name": "P1"}],
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        status=200,
+    )
+    fields = _client().get_project_fields("PVT_1")
+    assert fields[0]["name"] == "Priority"
+    assert fields[0]["options"][0]["id"] == "opt_1"
+
+
+@responses.activate
+def test_create_issue() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {"createIssue": {"issue": {"id": "I_1", "number": 42, "title": "Bootstrap"}}}
+        },
+        status=200,
+    )
+    out = _client().create_issue("R_1", "Bootstrap", "body", milestone_id="MI_1")
+    assert out["number"] == 42
+
+
+@responses.activate
+def test_add_item_to_project_returns_item_id() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"addProjectV2ItemById": {"item": {"id": "PVTI_1"}}}},
+        status=200,
+    )
+    assert _client().add_item_to_project("PVT_1", "I_1") == "PVTI_1"
+
+
+@responses.activate
+def test_graphql_error_response_raises() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"errors": [{"message": "Could not resolve to an Organization"}]},
+        status=200,
+    )
+    with pytest.raises(GraphQLError, match="Could not resolve"):
+        _client().get_org_id("nope")
+
+
+@responses.activate
+def test_http_error_after_retries_raises() -> None:
+    # 4xx that isn't in the retry list bubbles up immediately.
+    responses.add(responses.POST, GRAPHQL_URL, status=401)
+    with pytest.raises(Exception):  # noqa: B017 - requests.HTTPError
+        _client().get_org_id("nope")
+
+
+@responses.activate
+def test_request_body_includes_query_and_variables() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"organization": {"id": "O_1"}}},
+        status=200,
+    )
+    _client().get_org_id("example-org")
+
+    sent = responses.calls[0].request
+    assert sent.body is not None
+    body_text = sent.body.decode() if isinstance(sent.body, bytes) else sent.body
+    assert "example-org" in body_text
+    assert "query" in body_text

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+
 import pytest
+import requests
 import responses
 
 from plynth.engine.api_base import GHESClient
@@ -144,7 +147,7 @@ def test_graphql_error_response_raises() -> None:
 def test_http_error_after_retries_raises() -> None:
     # 4xx that isn't in the retry list bubbles up immediately.
     responses.add(responses.POST, GRAPHQL_URL, status=401)
-    with pytest.raises(Exception):  # noqa: B017 - requests.HTTPError
+    with pytest.raises(requests.HTTPError):
         _client().get_org_id("nope")
 
 
@@ -161,5 +164,14 @@ def test_request_body_includes_query_and_variables() -> None:
     sent = responses.calls[0].request
     assert sent.body is not None
     body_text = sent.body.decode() if isinstance(sent.body, bytes) else sent.body
-    assert "example-org" in body_text
-    assert "query" in body_text
+    payload = json.loads(body_text)
+
+    # Assert query and variables are sent as separate JSON members — not
+    # interpolated into the query string. A regression that inlined the login
+    # into `query` would fail the variables check below.
+    assert "query" in payload
+    assert "variables" in payload
+    assert payload["variables"] == {"login": "example-org"}
+    # The query itself should NOT contain the login literal — it must be a
+    # parameterized GraphQL operation.
+    assert "example-org" not in payload["query"]

--- a/tests/test_phases_e2e.py
+++ b/tests/test_phases_e2e.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 
 import responses
+import yaml
 
 from plynth.engine.api_base import GHESClient
 from plynth.engine.graphql_client import GraphQLClient
@@ -266,29 +267,70 @@ def test_phases_e2e_happy_path(
     for iss in state.issues.values():
         assert iss.item_id.startswith("PVTI_")
 
-    # Phase 5 — body update should have run for issues containing {PREFIX}-### refs
+    # Phase 5 — body update should have run for the two issues with crossrefs.
     assert state.is_phase_complete(PHASE_5_REFERENCES_AND_DEPS)
-    # ACME-002 body references {PREFIX}-001 → should be rewritten to "#47"
-    rewritten_bodies = [body for _, body in dispatcher.body_updates]
-    assert any("#47" in b for b in rewritten_bodies)
-    # Dependency edges wired (ACME-002 blocked_by ACME-001, ACME-003 blocked_by ACME-002)
-    assert len(dispatcher.add_blocked_by_calls) == 2
-    assert len(state.dependencies_created) == 2
 
-    # Phase 7
+    # Map node_id → rewritten body and assert each expected rewrite explicitly.
+    # Issues are created in template order: 001=#47, 002=#48, 003=#49.
+    body_by_node = dict(dispatcher.body_updates)
+    issue_002_node = state.issues["002"].node_id
+    issue_003_node = state.issues["003"].node_id
+    assert body_by_node[issue_002_node] == "Depends on #47 completing."
+    assert body_by_node[issue_003_node] == "Final hardening of Acme. After #48."
+    # Issue 001 has no crossref so its body should NOT be updated.
+    assert state.issues["001"].node_id not in body_by_node
+
+    # Dependency edges: assert exact (issueId, blockingIssueId) pairs, not just count.
+    issue_001_node = state.issues["001"].node_id
+    expected_edges = {
+        # 002 blocked_by 001
+        (issue_002_node, issue_001_node),
+        # 003 blocked_by 002
+        (issue_003_node, issue_002_node),
+    }
+    assert set(dispatcher.add_blocked_by_calls) == expected_edges
+
+    # The state's recorded dependency edges use template_ids, not node_ids.
+    recorded = {(e.blocked, e.blocker) for e in state.dependencies_created}
+    assert recorded == {("002", "001"), ("003", "002")}
+
+    # Phase 7 — final state written.
     assert state.is_phase_complete(PHASE_7_STATE_FILE)
-
-    # State file written
     assert state_path.exists()
+
+    # Reload from disk and verify on-disk serialization. A YAML serialization
+    # bug would otherwise pass the in-memory assertions above.
+    with open(state_path, encoding="utf-8") as f:
+        on_disk = StateFile.model_validate(yaml.safe_load(f))
+    assert on_disk.project is not None
+    assert on_disk.project.node_id == "PVT_1"
+    assert on_disk.project.number == 7
+    assert set(on_disk.milestones.keys()) == {"M1", "M2"}
+    assert set(on_disk.issues.keys()) == {"001", "002", "003"}
+    assert {iss.number for iss in on_disk.issues.values()} == {47, 48, 49}
+    assert "_status" in on_disk.fields
+    assert on_disk.fields["_status"].options["Backlog"] == "opt_backlog"
+    on_disk_edges = {(e.blocked, e.blocker) for e in on_disk.dependencies_created}
+    assert on_disk_edges == {("002", "001"), ("003", "002")}
+    for phase in (
+        PHASE_1_PROJECT_AND_FIELDS,
+        PHASE_2_MILESTONES,
+        PHASE_3_ISSUES,
+        PHASE_4_PROJECT_ITEMS,
+        PHASE_5_REFERENCES_AND_DEPS,
+        PHASE_7_STATE_FILE,
+    ):
+        assert on_disk.is_phase_complete(phase)
 
 
 @responses.activate
-def test_phases_e2e_resume_is_noop(
+def test_phases_e2e_resume_from_disk_is_noop(
     minimal_template: TemplateDefinition,
     minimal_instance: InstanceConfig,
     tmp_path: Path,
 ) -> None:
-    """A second `execute()` call after a successful run should issue no API calls."""
+    """After a successful run, building a fresh orchestrator from the on-disk
+    state file should issue no API calls — exercising the persisted resume path."""
     dispatcher = _GraphQLDispatcher()
     responses.add_callback(
         responses.POST, GRAPHQL_URL, callback=dispatcher, content_type="application/json"
@@ -296,12 +338,27 @@ def test_phases_e2e_resume_is_noop(
     _register_milestones(milestone_count=2)
 
     state_path = tmp_path / "state.yaml"
-    orch, state = _build_orchestrator(minimal_template, minimal_instance, state_path)
+    orch, _ = _build_orchestrator(minimal_template, minimal_instance, state_path)
     orch.execute()
 
     first_run_call_count = len(responses.calls)
     assert first_run_call_count > 0
 
-    # Second run on the same orchestrator + state should skip every phase.
-    orch.execute()
+    # Build a fresh orchestrator by loading state from disk — simulating a
+    # restart. This is what `cli._init_or_load_state` does in production.
+    with open(state_path, encoding="utf-8") as f:
+        loaded_state = StateFile.model_validate(yaml.safe_load(f))
+
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0)
+    fresh_orch = PhaseOrchestrator(
+        plan=plan(minimal_template, minimal_instance),
+        gql=GraphQLClient(base),
+        rest=RESTClient(base),
+        state=loaded_state,
+        state_path=state_path,
+        logger=logging.getLogger("plynth.test"),
+    )
+    fresh_orch.execute()
+
+    # No new API calls should have been issued — every phase already complete.
     assert len(responses.calls) == first_run_call_count

--- a/tests/test_phases_e2e.py
+++ b/tests/test_phases_e2e.py
@@ -1,0 +1,307 @@
+"""End-to-end orchestrator test against a mocked GHES server.
+
+Exercises Phases 1→5 + 7 against a single in-test GraphQL dispatcher and a
+sequenced REST mock. Asserts the resulting state file contents and that a
+second run of `execute()` is a no-op (resume behavior).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import responses
+
+from plynth.engine.api_base import GHESClient
+from plynth.engine.graphql_client import GraphQLClient
+from plynth.engine.phases import PhaseOrchestrator
+from plynth.engine.planner import plan
+from plynth.engine.rest_client import RESTClient
+from plynth.models.instance import InstanceConfig
+from plynth.models.state import (
+    PHASE_1_PROJECT_AND_FIELDS,
+    PHASE_2_MILESTONES,
+    PHASE_3_ISSUES,
+    PHASE_4_PROJECT_ITEMS,
+    PHASE_5_REFERENCES_AND_DEPS,
+    PHASE_7_STATE_FILE,
+    StateFile,
+)
+from plynth.models.template import TemplateDefinition
+
+GHES_URL = "https://ghes.example.com"
+GRAPHQL_URL = f"{GHES_URL}/api/graphql"
+
+
+class _GraphQLDispatcher:
+    """Dispatches GraphQL POSTs by inspecting the query body.
+
+    The plynth GraphQL client uses a single endpoint, so `responses` cannot
+    distinguish operations by URL alone — we route on substrings of the query
+    body and produce real issue numbers in the order they were created.
+    """
+
+    def __init__(self) -> None:
+        self.next_issue_number = 47  # non-sequential / non-1-based on purpose
+        self.next_item_id = 1
+        self.created_issue_node_ids: list[str] = []
+        self.body_updates: list[tuple[str, str]] = []
+        self.add_blocked_by_calls: list[tuple[str, str]] = []
+
+    def __call__(self, request) -> tuple[int, dict, str]:  # type: ignore[no-untyped-def]
+        payload = json.loads(request.body)
+        query = payload["query"]
+        variables = payload.get("variables", {})
+
+        if "GET_ORG_ID" in query or "organization(login" in query:
+            return (200, {}, json.dumps({"data": {"organization": {"id": "O_1"}}}))
+
+        if "repository(owner" in query and "name" in query:
+            return (200, {}, json.dumps({"data": {"repository": {"id": "R_1"}}}))
+
+        if "createProjectV2(" in query:
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "createProjectV2": {
+                                "projectV2": {
+                                    "id": "PVT_1",
+                                    "number": 7,
+                                    "url": f"{GHES_URL}/orgs/example-org/projects/7",
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
+
+        if "createProjectV2Field(" in query:
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "createProjectV2Field": {
+                                "projectV2Field": {
+                                    "id": f"PVTSSF_{variables['name']}",
+                                    "name": variables["name"],
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
+
+        if "node(id:" in query and "ProjectV2" in query:
+            # get_project_fields — return Status (built-in) plus our custom fields.
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "node": {
+                                "fields": {
+                                    "nodes": [
+                                        {
+                                            "id": "PVTSSF_status",
+                                            "name": "Status",
+                                            "options": [
+                                                {"id": "opt_backlog", "name": "Backlog"},
+                                                {"id": "opt_done", "name": "Done"},
+                                            ],
+                                        },
+                                        {
+                                            "id": "PVTSSF_Priority",
+                                            "name": "Priority",
+                                            "options": [
+                                                {"id": "opt_p1", "name": "P1"},
+                                                {"id": "opt_p2", "name": "P2"},
+                                                {"id": "opt_platform", "name": "Platform"},
+                                            ],
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
+
+        if "createIssue(" in query:
+            num = self.next_issue_number
+            self.next_issue_number += 1
+            node_id = f"I_{num}"
+            self.created_issue_node_ids.append(node_id)
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "createIssue": {
+                                "issue": {
+                                    "id": node_id,
+                                    "number": num,
+                                    "title": variables["title"],
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
+
+        if "addProjectV2ItemById(" in query:
+            item_id = f"PVTI_{self.next_item_id}"
+            self.next_item_id += 1
+            return (
+                200,
+                {},
+                json.dumps({"data": {"addProjectV2ItemById": {"item": {"id": item_id}}}}),
+            )
+
+        if "updateProjectV2ItemFieldValue(" in query:
+            return (
+                200,
+                {},
+                json.dumps({"data": {"updateProjectV2ItemFieldValue": {"clientMutationId": None}}}),
+            )
+
+        if "updateIssue(" in query:
+            self.body_updates.append((variables["issueId"], variables["body"]))
+            return (
+                200,
+                {},
+                json.dumps({"data": {"updateIssue": {"issue": {"id": variables["issueId"]}}}}),
+            )
+
+        if "addBlockedBy" in query or "blockedByIssues" in query:
+            self.add_blocked_by_calls.append(
+                (variables.get("issueId", ""), variables.get("blockingIssueId", ""))
+            )
+            return (200, {}, json.dumps({"data": {"addBlockedBy": {"clientMutationId": None}}}))
+
+        return (500, {}, json.dumps({"errors": [{"message": f"Unrouted query: {query[:80]}"}]}))
+
+
+def _register_milestones(milestone_count: int) -> None:
+    """Register sequential REST milestone responses."""
+    url = f"{GHES_URL}/api/v3/repos/example-org/acme/milestones"
+    for i in range(1, milestone_count + 1):
+        responses.add(
+            responses.POST,
+            url,
+            json={"number": i, "node_id": f"MI_{i}", "title": f"M{i}"},
+            status=201,
+        )
+
+
+def _build_orchestrator(
+    template: TemplateDefinition,
+    instance: InstanceConfig,
+    state_path: Path,
+) -> tuple[PhaseOrchestrator, StateFile]:
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0)
+    gql = GraphQLClient(base)
+    rest = RESTClient(base)
+    state = StateFile(ghes_url=GHES_URL, org=instance.org)
+    state.repo = None  # populated by phase 1
+    ep = plan(template, instance)
+    return (
+        PhaseOrchestrator(
+            plan=ep,
+            gql=gql,
+            rest=rest,
+            state=state,
+            state_path=state_path,
+            logger=logging.getLogger("plynth.test"),
+        ),
+        state,
+    )
+
+
+@responses.activate
+def test_phases_e2e_happy_path(
+    minimal_template: TemplateDefinition,
+    minimal_instance: InstanceConfig,
+    tmp_path: Path,
+) -> None:
+    dispatcher = _GraphQLDispatcher()
+    responses.add_callback(
+        responses.POST, GRAPHQL_URL, callback=dispatcher, content_type="application/json"
+    )
+    _register_milestones(milestone_count=2)
+
+    state_path = tmp_path / "state.yaml"
+    orch, state = _build_orchestrator(minimal_template, minimal_instance, state_path)
+    orch.execute()
+
+    # Phase 1
+    assert state.is_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+    assert state.project is not None
+    assert state.project.node_id == "PVT_1"
+    assert state.project.number == 7
+    assert state.repo is not None
+    assert state.repo.node_id == "R_1"
+    # Status field captured under the synthetic "_status" key
+    assert "_status" in state.fields
+    assert state.fields["_status"].options["Backlog"] == "opt_backlog"
+    assert "priority" in state.fields
+
+    # Phase 2 — milestones via REST
+    assert state.is_phase_complete(PHASE_2_MILESTONES)
+    assert set(state.milestones.keys()) == {"M1", "M2"}
+
+    # Phase 3 — issue numbers come from the dispatcher (47, 48, 49)
+    assert state.is_phase_complete(PHASE_3_ISSUES)
+    assert {iss.number for iss in state.issues.values()} == {47, 48, 49}
+
+    # Phase 4
+    assert state.is_phase_complete(PHASE_4_PROJECT_ITEMS)
+    for iss in state.issues.values():
+        assert iss.item_id.startswith("PVTI_")
+
+    # Phase 5 — body update should have run for issues containing {PREFIX}-### refs
+    assert state.is_phase_complete(PHASE_5_REFERENCES_AND_DEPS)
+    # ACME-002 body references {PREFIX}-001 → should be rewritten to "#47"
+    rewritten_bodies = [body for _, body in dispatcher.body_updates]
+    assert any("#47" in b for b in rewritten_bodies)
+    # Dependency edges wired (ACME-002 blocked_by ACME-001, ACME-003 blocked_by ACME-002)
+    assert len(dispatcher.add_blocked_by_calls) == 2
+    assert len(state.dependencies_created) == 2
+
+    # Phase 7
+    assert state.is_phase_complete(PHASE_7_STATE_FILE)
+
+    # State file written
+    assert state_path.exists()
+
+
+@responses.activate
+def test_phases_e2e_resume_is_noop(
+    minimal_template: TemplateDefinition,
+    minimal_instance: InstanceConfig,
+    tmp_path: Path,
+) -> None:
+    """A second `execute()` call after a successful run should issue no API calls."""
+    dispatcher = _GraphQLDispatcher()
+    responses.add_callback(
+        responses.POST, GRAPHQL_URL, callback=dispatcher, content_type="application/json"
+    )
+    _register_milestones(milestone_count=2)
+
+    state_path = tmp_path / "state.yaml"
+    orch, state = _build_orchestrator(minimal_template, minimal_instance, state_path)
+    orch.execute()
+
+    first_run_call_count = len(responses.calls)
+    assert first_run_call_count > 0
+
+    # Second run on the same orchestrator + state should skip every phase.
+    orch.execute()
+    assert len(responses.calls) == first_run_call_count

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -82,11 +82,11 @@ def test_plan_skip_milestone_cascades(
     minimal_instance.skip_milestones = ["M2"]
     ep = plan(minimal_template, minimal_instance)
     assert [m.id for m in ep.milestones] == ["M1"]
-    # ACME-003 lives on M2 → should be skipped
+    # 003 lives on M2 → should be skipped
     issue_ids = [i.template_id for i in ep.issues]
-    assert "{PREFIX}-003" not in issue_ids
-    assert "{PREFIX}-001" in issue_ids
-    assert "{PREFIX}-002" in issue_ids
+    assert "003" not in issue_ids
+    assert "001" in issue_ids
+    assert "002" in issue_ids
 
 
 def test_plan_skip_milestone_trims_dependencies(
@@ -94,12 +94,12 @@ def test_plan_skip_milestone_trims_dependencies(
 ) -> None:
     minimal_instance.skip_milestones = ["M1"]
     ep = plan(minimal_template, minimal_instance)
-    # All deps should be trimmed since M1 is gone (ACME-001, ACME-002 removed)
+    # All deps should be trimmed since M1 is gone (001, 002 removed)
     only_issue = ep.issues[0]
-    assert only_issue.template_id == "{PREFIX}-003"
+    assert only_issue.template_id == "003"
     assert only_issue.blocked_by == []
     # The skipped ref should be recorded
-    assert "{PREFIX}-002" in only_issue.skipped_blocked_by
+    assert "002" in only_issue.skipped_blocked_by
     assert ep.warnings, "Expected warnings about trimmed deps"
 
 

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+import responses
+
+from plynth.engine.api_base import GHESClient
+from plynth.engine.rest_client import RESTClient
+
+GHES_URL = "https://ghes.example.com"
+MILESTONE_URL = f"{GHES_URL}/api/v3/repos/example-org/acme/milestones"
+
+
+def _client() -> RESTClient:
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0)
+    return RESTClient(base)
+
+
+@responses.activate
+def test_create_milestone_happy_path() -> None:
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        json={"number": 3, "node_id": "MI_1", "title": "Foundation"},
+        status=201,
+    )
+    result = _client().create_milestone(
+        owner="example-org",
+        repo="acme",
+        title="Foundation",
+        description="d",
+        due_on="2026-05-15T00:00:00Z",
+    )
+    assert result == {"number": 3, "node_id": "MI_1", "title": "Foundation"}
+
+    sent_body = json.loads(responses.calls[0].request.body)
+    assert sent_body["title"] == "Foundation"
+    assert sent_body["due_on"] == "2026-05-15T00:00:00Z"
+
+
+@responses.activate
+def test_create_milestone_omits_due_on_if_none() -> None:
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        json={"number": 1, "node_id": "MI_2", "title": "T"},
+        status=201,
+    )
+    _client().create_milestone(owner="example-org", repo="acme", title="T")
+    sent_body = json.loads(responses.calls[0].request.body)
+    assert "due_on" not in sent_body
+
+
+@responses.activate
+def test_create_milestone_422_raises() -> None:
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        json={"message": "Validation failed"},
+        status=422,
+    )
+    with pytest.raises(requests.HTTPError):
+        _client().create_milestone(owner="example-org", repo="acme", title="T")


### PR DESCRIPTION
## Summary
- Add HTTP-mocked tests for the engine layer using the \`responses\` library.
- 62 tests total (was 41), ~0.3s wall time. No real GHES instance required.

## What's covered
- **\`test_api_base.py\`** — write-delay enforcement (mocked time), \`Retry-After\` handling, exponential backoff on 503, no-retry on 200.
- **\`test_graphql_client.py\`** — happy paths for all mutations/queries (\`get_org_id\`, \`get_repo_id\`, \`create_project\`, \`create_field\`, \`get_project_fields\`, \`create_issue\`, \`add_item_to_project\`); \`GraphQLError\` raised on \`errors[]\` array; HTTP error passthrough; request body inspection.
- **\`test_rest_client.py\`** — milestone create happy + 422 + \`due_on\` omitted when None.
- **\`test_phases_e2e.py\`** — full Phase 1→7 happy path against an in-test GraphQL dispatcher + sequenced REST milestone mocks. Asserts state file contents (project, fields, milestones, issues, item IDs, body rewrites with \`#real_number\`, dependency edges) and that a second \`execute()\` is a no-op (resume behavior).

## Fixture fix
Caught while writing the e2e test: the \`minimal-template.yaml\` fixture used \`template_id: \"{PREFIX}-001\"\` but production templates use bare \`\"001\"\` (the orchestrator adds the prefix at lookup time). Updated the fixture and the two planner tests that referenced the old format.

## Test plan
- [x] \`pytest -q\` → 62 passed
- [x] \`ruff check .\` clean
- [x] \`ruff format --check .\` clean
- [x] \`mypy plynth\` clean (strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)