### PR TITLE
PR 5: Error handling and request timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- `plynth/errors.py` — user-facing error hierarchy: `PlynthError` (base) →
+  `AuthError`, `NotFoundError`, `NetworkError`, `ConfigError`. `GraphQLError`
+  is now also a `PlynthError` subclass so it's caught by the same handler.
+- `--timeout-seconds` CLI flag (default 30) on both `create` and `resolve`.
+- `request_timeout_s` parameter on `GHESClient`; threaded through to every
+  `session.post` call in `graphql_client` and `rest_client`.
+- `tests/test_errors.py` — covers 401→AuthError, "Could not resolve"→
+  NotFoundError, timeout→NetworkError, connection error→NetworkError, REST
+  401/404 mapping, and CLI top-level handler exit code 2.
+
+### Changed
+- `cli.main` now wraps the command dispatch in `try/except PlynthError`,
+  printing `Error: {e}` to stderr and exiting with code 2. Unexpected
+  exceptions still raise so tracebacks aren't hidden.
+- YAML and Pydantic validation failures during template/instance/state
+  loading now raise `ConfigError` with a friendly message instead of a
+  bare exception.
+- GraphQL "Could not resolve to ..." / "could not be found" errors are
+  classified as `NotFoundError` (with the GHES URL appended). Other
+  GraphQL errors still surface as `GraphQLError`.
 - HTTP-mocked integration tests under `tests/`:
   - `test_api_base.py` — write-delay enforcement, retry-after handling,
     exponential backoff on 503.

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -12,12 +12,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from plynth.engine.api_base import GHESClient
 from plynth.engine.graphql_client import GraphQLClient
 from plynth.engine.phases import PhaseOrchestrator
 from plynth.engine.planner import format_dry_run, plan
 from plynth.engine.rest_client import RESTClient
+from plynth.errors import ConfigError, PlynthError
 from plynth.models.instance import InstanceConfig
 from plynth.models.state import (
     PHASE_5_REFERENCES_AND_DEPS,
@@ -52,6 +54,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=1000,
         help="Delay between API writes (ms)",
     )
+    create_parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=30,
+        help="Per-request HTTP timeout (seconds, default 30)",
+    )
     create_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
 
     # --- resolve command ---
@@ -62,6 +70,12 @@ def build_parser() -> argparse.ArgumentParser:
     resolve_parser.add_argument("--template", required=True, help="Path to template YAML")
     resolve_parser.add_argument("--instance", required=True, help="Path to instance config YAML")
     resolve_parser.add_argument("--token", help="GHES PAT (or set GHES_TOKEN env var)")
+    resolve_parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=30,
+        help="Per-request HTTP timeout (seconds, default 30)",
+    )
     resolve_parser.add_argument("-v", "--verbose", action="store_true")
 
     return parser
@@ -79,10 +93,14 @@ def main() -> None:
     )
     log = logging.getLogger("plynth")
 
-    if args.command == "create":
-        _cmd_create(args, log)
-    elif args.command == "resolve":
-        _cmd_resolve(args, log)
+    try:
+        if args.command == "create":
+            _cmd_create(args, log)
+        elif args.command == "resolve":
+            _cmd_resolve(args, log)
+    except PlynthError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
 
 
 def _cmd_create(args: argparse.Namespace, log: logging.Logger) -> None:
@@ -103,7 +121,12 @@ def _cmd_create(args: argparse.Namespace, log: logging.Logger) -> None:
     token = _get_token(args)
 
     # 5. Initialize clients
-    base = GHESClient(instance.ghes_url, token, write_delay_ms=args.write_delay_ms)
+    base = GHESClient(
+        instance.ghes_url,
+        token,
+        write_delay_ms=args.write_delay_ms,
+        request_timeout_s=args.timeout_seconds,
+    )
     gql = GraphQLClient(base)
     rest = RESTClient(base)
 
@@ -132,7 +155,7 @@ def _cmd_resolve(args: argparse.Namespace, log: logging.Logger) -> None:
     execution_plan = plan(template, instance)
 
     token = _get_token(args)
-    base = GHESClient(instance.ghes_url, token)
+    base = GHESClient(instance.ghes_url, token, request_timeout_s=args.timeout_seconds)
     gql = GraphQLClient(base)
     rest = RESTClient(base)
 
@@ -158,21 +181,45 @@ def _cmd_resolve(args: argparse.Namespace, log: logging.Logger) -> None:
 
 
 def _load_template(path: str) -> TemplateDefinition:
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    return TemplateDefinition.model_validate(data)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ConfigError(f"Template file not found: {path}") from e
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Invalid YAML in template '{path}': {e}") from e
+    try:
+        return TemplateDefinition.model_validate(data)
+    except ValidationError as e:
+        raise ConfigError(f"Template '{path}' failed schema validation:\n{e}") from e
 
 
 def _load_instance(path: str) -> InstanceConfig:
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    return InstanceConfig.model_validate(data)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ConfigError(f"Instance file not found: {path}") from e
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Invalid YAML in instance '{path}': {e}") from e
+    try:
+        return InstanceConfig.model_validate(data)
+    except ValidationError as e:
+        raise ConfigError(f"Instance '{path}' failed schema validation:\n{e}") from e
 
 
 def _load_state(path: Path) -> StateFile:
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    return StateFile.model_validate(data)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ConfigError(f"State file not found: {path}") from e
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Invalid YAML in state file '{path}': {e}") from e
+    try:
+        return StateFile.model_validate(data)
+    except ValidationError as e:
+        raise ConfigError(f"State file '{path}' failed schema validation:\n{e}") from e
 
 
 def _get_token(args: argparse.Namespace) -> str:

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -31,6 +31,17 @@ from plynth.models.state import (
 from plynth.models.template import TemplateDefinition
 
 
+def _positive_int(value: str) -> int:
+    """argparse type for flags that must be a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"expected integer, got '{value}'") from e
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {ivalue}")
+    return ivalue
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the plynth argparse parser. Exposed for test reuse."""
     parser = argparse.ArgumentParser(
@@ -56,9 +67,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     create_parser.add_argument(
         "--timeout-seconds",
-        type=int,
+        type=_positive_int,
         default=30,
-        help="Per-request HTTP timeout (seconds, default 30)",
+        help="Per-request HTTP timeout (seconds, default 30, must be > 0)",
     )
     create_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
 
@@ -72,9 +83,9 @@ def build_parser() -> argparse.ArgumentParser:
     resolve_parser.add_argument("--token", help="GHES PAT (or set GHES_TOKEN env var)")
     resolve_parser.add_argument(
         "--timeout-seconds",
-        type=int,
+        type=_positive_int,
         default=30,
-        help="Per-request HTTP timeout (seconds, default 30)",
+        help="Per-request HTTP timeout (seconds, default 30, must be > 0)",
     )
     resolve_parser.add_argument("-v", "--verbose", action="store_true")
 

--- a/plynth/engine/api_base.py
+++ b/plynth/engine/api_base.py
@@ -14,6 +14,7 @@ class GHESClient:
         token: str,
         write_delay_ms: int = 1000,
         max_retries: int = 3,
+        request_timeout_s: int = 30,
     ):
         self.ghes_url = ghes_url
         self.session = requests.Session()
@@ -25,6 +26,7 @@ class GHESClient:
         )
         self.write_delay_ms = write_delay_ms
         self.max_retries = max_retries
+        self.request_timeout_s = request_timeout_s
         self._last_write_time: float = 0.0
 
     def _wait_for_write_delay(self) -> None:

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -1,16 +1,28 @@
 from __future__ import annotations
 
+import requests
+
 from plynth.engine.api_base import GHESClient
+from plynth.errors import AuthError, NetworkError, NotFoundError, PlynthError
 from plynth.queries import mutations, queries
 
 
-class GraphQLError(Exception):
+class GraphQLError(PlynthError):
     """Raised when a GraphQL response contains errors."""
 
     def __init__(self, errors: list[dict]) -> None:
         self.errors = errors
         messages = [e.get("message", str(e)) for e in errors]
         super().__init__(f"GraphQL errors: {'; '.join(messages)}")
+
+
+def _classify_graphql_errors(errors: list[dict], ghes_url: str) -> PlynthError:
+    """Map GraphQL `errors[]` entries to a friendly PlynthError subclass."""
+    for err in errors:
+        msg = err.get("message", "")
+        if "Could not resolve to" in msg or "could not be found" in msg.lower():
+            return NotFoundError(f"{msg.rstrip('.')} (GHES: {ghes_url})")
+    return GraphQLError(errors)
 
 
 class GraphQLClient:
@@ -32,23 +44,41 @@ class GraphQLClient:
             self.base._wait_for_write_delay()
 
         for attempt in range(self.base.max_retries):
-            response = self.base.session.post(
-                self.endpoint,
-                json={"query": query, "variables": variables or {}},
-            )
+            try:
+                response = self.base.session.post(
+                    self.endpoint,
+                    json={"query": query, "variables": variables or {}},
+                    timeout=self.base.request_timeout_s,
+                )
+            except requests.Timeout as e:
+                raise NetworkError(
+                    f"GraphQL request to {self.base.ghes_url} timed out "
+                    f"after {self.base.request_timeout_s}s"
+                ) from e
+            except requests.ConnectionError as e:
+                raise NetworkError(f"Could not connect to {self.base.ghes_url}: {e}") from e
 
             if response.ok:
                 result = response.json()
                 if "errors" in result:
-                    raise GraphQLError(result["errors"])
+                    raise _classify_graphql_errors(result["errors"], self.base.ghes_url)
                 if is_mutation:
                     self.base._record_write()
                 return result["data"]
 
+            if response.status_code == 401:
+                raise AuthError(
+                    f"Token rejected by {self.base.ghes_url}; verify GHES_TOKEN "
+                    f"scopes include `repo` and `project`."
+                )
+
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()
 
-        raise RuntimeError("Max retries exceeded for GraphQL call")
+        raise NetworkError(
+            f"Max retries ({self.base.max_retries}) exceeded for GraphQL "
+            f"call to {self.base.ghes_url}"
+        )
 
     # ── Preflight queries ──────────────────────────────────
 

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import requests
+
 from plynth.engine.api_base import GHESClient
+from plynth.errors import AuthError, NetworkError, NotFoundError
 
 
 class RESTClient:
@@ -31,7 +34,17 @@ class RESTClient:
             payload["due_on"] = due_on
 
         for attempt in range(self.base.max_retries):
-            response = self.base.session.post(url, json=payload)
+            try:
+                response = self.base.session.post(
+                    url, json=payload, timeout=self.base.request_timeout_s
+                )
+            except requests.Timeout as e:
+                raise NetworkError(
+                    f"REST request to {url} timed out after {self.base.request_timeout_s}s"
+                ) from e
+            except requests.ConnectionError as e:
+                raise NetworkError(f"Could not connect to {self.base.ghes_url}: {e}") from e
+
             if response.ok:
                 self.base._record_write()
                 data = response.json()
@@ -40,7 +53,18 @@ class RESTClient:
                     "node_id": data["node_id"],
                     "title": data["title"],
                 }
+
+            if response.status_code == 401:
+                raise AuthError(
+                    f"Token rejected by {self.base.ghes_url}; verify GHES_TOKEN "
+                    f"scopes include `repo` and `project`."
+                )
+            if response.status_code == 404:
+                raise NotFoundError(f"Repository {owner}/{repo} not found on {self.base.ghes_url}")
+
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()
 
-        raise RuntimeError(f"Max retries exceeded creating milestone '{title}'")
+        raise NetworkError(
+            f"Max retries ({self.base.max_retries}) exceeded creating milestone '{title}'"
+        )

--- a/plynth/errors.py
+++ b/plynth/errors.py
@@ -1,0 +1,38 @@
+"""plynth error hierarchy.
+
+User-facing exceptions raised by the engine and CLI. The CLI's top-level
+handler prints `Error: {e}` and exits 2 for any subclass of `PlynthError`,
+so prefer raising one of these over generic `Exception` for actionable
+failures.
+"""
+
+from __future__ import annotations
+
+
+class PlynthError(Exception):
+    """Base class for all plynth user-facing errors."""
+
+
+class AuthError(PlynthError):
+    """Token rejected (HTTP 401) or insufficient scopes."""
+
+
+class NotFoundError(PlynthError):
+    """A referenced GitHub resource (org, repo, project) does not exist."""
+
+
+class NetworkError(PlynthError):
+    """Connection failure, timeout, or other transport-level error."""
+
+
+class ConfigError(PlynthError):
+    """Local configuration problem: missing file, invalid YAML, schema error."""
+
+
+__all__ = [
+    "PlynthError",
+    "AuthError",
+    "NotFoundError",
+    "NetworkError",
+    "ConfigError",
+]

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -43,3 +43,51 @@ def test_unknown_subcommand_rejected() -> None:
     parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["bogus"])
+
+
+def test_timeout_seconds_rejects_zero() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "create",
+                "--template",
+                "t.yaml",
+                "--instance",
+                "i.yaml",
+                "--timeout-seconds",
+                "0",
+            ]
+        )
+
+
+def test_timeout_seconds_rejects_negative() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "create",
+                "--template",
+                "t.yaml",
+                "--instance",
+                "i.yaml",
+                "--timeout-seconds",
+                "-5",
+            ]
+        )
+
+
+def test_timeout_seconds_accepts_positive() -> None:
+    parser = build_parser()
+    ns = parser.parse_args(
+        [
+            "create",
+            "--template",
+            "t.yaml",
+            "--instance",
+            "i.yaml",
+            "--timeout-seconds",
+            "60",
+        ]
+    )
+    assert ns.timeout_seconds == 60

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -89,29 +89,33 @@ def test_graphql_connection_error_raises_network_error() -> None:
         _gql().get_org_id("nope")
 
 
-def test_graphql_timeout_value_threaded_from_client() -> None:
-    """The timeout passed to session.post should be the client's request_timeout_s."""
+def test_graphql_timeout_kwarg_passed_to_session_post() -> None:
+    """The client's `request_timeout_s` must be forwarded to session.post as
+    the `timeout=` kwarg — not just embedded in error messages. Patch
+    session.post to capture the kwargs and assert the value directly."""
+    from unittest.mock import MagicMock, patch
+
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0, request_timeout_s=7)
+    gql = GraphQLClient(base)
+
+    fake_response = MagicMock()
+    fake_response.ok = True
+    fake_response.json.return_value = {"data": {"organization": {"id": "O_1"}}}
+
+    with patch.object(base.session, "post", return_value=fake_response) as mock_post:
+        gql.get_org_id("example-org")
+
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["timeout"] == 7
+
+
+def test_graphql_timeout_message_uses_configured_value() -> None:
+    """A timeout error surfaces with the client's configured timeout in the message."""
     base = GHESClient(GHES_URL, "tok", write_delay_ms=0, request_timeout_s=7)
     gql = GraphQLClient(base)
 
     @responses.activate
     def _do() -> None:
-        responses.add(
-            responses.POST,
-            GRAPHQL_URL,
-            json={"data": {"organization": {"id": "O_1"}}},
-            status=200,
-        )
-        gql.get_org_id("example-org")
-        # The Request object captured by `responses` doesn't expose timeout, so
-        # we instead check that a NetworkError surfaces when the call times out
-        # mentioning the configured value.
-
-    _do()
-
-    # Now test the timeout message uses the configured value.
-    @responses.activate
-    def _timeout_check() -> None:
         def _timeout(_req: object) -> None:
             raise requests.Timeout()
 
@@ -119,7 +123,7 @@ def test_graphql_timeout_value_threaded_from_client() -> None:
         with pytest.raises(NetworkError, match="timed out after 7s"):
             gql.get_org_id("nope")
 
-    _timeout_check()
+    _do()
 
 
 # ── REST client ────────────────────────────────────────────────

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,192 @@
+"""Tests for the friendly-error mapping in graphql_client and rest_client."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+import responses
+
+from plynth.engine.api_base import GHESClient
+from plynth.engine.graphql_client import GraphQLClient, GraphQLError
+from plynth.engine.rest_client import RESTClient
+from plynth.errors import AuthError, NetworkError, NotFoundError, PlynthError
+
+GHES_URL = "https://ghes.example.com"
+GRAPHQL_URL = f"{GHES_URL}/api/graphql"
+MILESTONE_URL = f"{GHES_URL}/api/v3/repos/example-org/acme/milestones"
+
+
+def _gql() -> GraphQLClient:
+    return GraphQLClient(GHESClient(GHES_URL, "tok", write_delay_ms=0))
+
+
+def _rest() -> RESTClient:
+    return RESTClient(GHESClient(GHES_URL, "tok", write_delay_ms=0))
+
+
+def test_error_hierarchy() -> None:
+    # All friendly errors are PlynthError; GraphQLError is also PlynthError now.
+    for exc_cls in (AuthError, NotFoundError, NetworkError, GraphQLError):
+        assert issubclass(exc_cls, PlynthError)
+
+
+# ── GraphQL client ──────────────────────────────────────────────
+
+
+@responses.activate
+def test_graphql_401_raises_auth_error() -> None:
+    responses.add(responses.POST, GRAPHQL_URL, status=401)
+    with pytest.raises(AuthError, match="Token rejected"):
+        _gql().get_org_id("nope")
+
+
+@responses.activate
+def test_graphql_could_not_resolve_raises_not_found() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "errors": [
+                {"message": "Could not resolve to an Organization with the login of 'nope'."}
+            ]
+        },
+        status=200,
+    )
+    with pytest.raises(NotFoundError, match="Could not resolve"):
+        _gql().get_org_id("nope")
+
+
+@responses.activate
+def test_graphql_other_error_raises_graphql_error() -> None:
+    """Errors that don't match the NotFoundError heuristic still raise GraphQLError."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"errors": [{"message": "Something else went wrong"}]},
+        status=200,
+    )
+    with pytest.raises(GraphQLError, match="Something else"):
+        _gql().get_org_id("nope")
+
+
+@responses.activate
+def test_graphql_timeout_raises_network_error() -> None:
+    def _timeout(_req: object) -> None:
+        raise requests.Timeout("simulated timeout")
+
+    responses.add_callback(responses.POST, GRAPHQL_URL, callback=_timeout)
+    with pytest.raises(NetworkError, match="timed out after 30s"):
+        _gql().get_org_id("nope")
+
+
+@responses.activate
+def test_graphql_connection_error_raises_network_error() -> None:
+    def _conn_err(_req: object) -> None:
+        raise requests.ConnectionError("name resolution failed")
+
+    responses.add_callback(responses.POST, GRAPHQL_URL, callback=_conn_err)
+    with pytest.raises(NetworkError, match="Could not connect"):
+        _gql().get_org_id("nope")
+
+
+def test_graphql_timeout_value_threaded_from_client() -> None:
+    """The timeout passed to session.post should be the client's request_timeout_s."""
+    base = GHESClient(GHES_URL, "tok", write_delay_ms=0, request_timeout_s=7)
+    gql = GraphQLClient(base)
+
+    @responses.activate
+    def _do() -> None:
+        responses.add(
+            responses.POST,
+            GRAPHQL_URL,
+            json={"data": {"organization": {"id": "O_1"}}},
+            status=200,
+        )
+        gql.get_org_id("example-org")
+        # The Request object captured by `responses` doesn't expose timeout, so
+        # we instead check that a NetworkError surfaces when the call times out
+        # mentioning the configured value.
+
+    _do()
+
+    # Now test the timeout message uses the configured value.
+    @responses.activate
+    def _timeout_check() -> None:
+        def _timeout(_req: object) -> None:
+            raise requests.Timeout()
+
+        responses.add_callback(responses.POST, GRAPHQL_URL, callback=_timeout)
+        with pytest.raises(NetworkError, match="timed out after 7s"):
+            gql.get_org_id("nope")
+
+    _timeout_check()
+
+
+# ── REST client ────────────────────────────────────────────────
+
+
+@responses.activate
+def test_rest_401_raises_auth_error() -> None:
+    responses.add(responses.POST, MILESTONE_URL, status=401)
+    with pytest.raises(AuthError, match="Token rejected"):
+        _rest().create_milestone(owner="example-org", repo="acme", title="T")
+
+
+@responses.activate
+def test_rest_404_raises_not_found_error() -> None:
+    responses.add(responses.POST, MILESTONE_URL, status=404, json={"message": "Not Found"})
+    with pytest.raises(NotFoundError, match="example-org/acme not found"):
+        _rest().create_milestone(owner="example-org", repo="acme", title="T")
+
+
+@responses.activate
+def test_rest_timeout_raises_network_error() -> None:
+    def _timeout(_req: object) -> None:
+        raise requests.Timeout("simulated")
+
+    responses.add_callback(responses.POST, MILESTONE_URL, callback=_timeout)
+    with pytest.raises(NetworkError, match="timed out after 30s"):
+        _rest().create_milestone(owner="example-org", repo="acme", title="T")
+
+
+@responses.activate
+def test_rest_connection_error_raises_network_error() -> None:
+    def _conn_err(_req: object) -> None:
+        raise requests.ConnectionError("connection refused")
+
+    responses.add_callback(responses.POST, MILESTONE_URL, callback=_conn_err)
+    with pytest.raises(NetworkError, match="Could not connect"):
+        _rest().create_milestone(owner="example-org", repo="acme", title="T")
+
+
+# ── CLI top-level handler ──────────────────────────────────────
+
+
+def test_cli_main_exits_2_on_plynth_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: object,  # pytest's tmp_path
+) -> None:
+    """A PlynthError raised during dry-run should produce `Error: ...` + exit code 2."""
+    from plynth import cli
+
+    # Point at a non-existent template — _load_template raises ConfigError.
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "plynth",
+            "create",
+            "--template",
+            "/does/not/exist.yaml",
+            "--instance",
+            "/does/not/exist.yaml",
+            "--dry-run",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Error: Template file not found" in captured.err

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 
 import pytest
-import requests
 import responses
 
 from plynth.engine.api_base import GHESClient
@@ -133,21 +132,15 @@ def test_add_item_to_project_returns_item_id() -> None:
 
 @responses.activate
 def test_graphql_error_response_raises() -> None:
+    # A generic GraphQL error that isn't classified as NotFoundError still
+    # surfaces as GraphQLError — see test_errors.py for the classification cases.
     responses.add(
         responses.POST,
         GRAPHQL_URL,
-        json={"errors": [{"message": "Could not resolve to an Organization"}]},
+        json={"errors": [{"message": "Some other GraphQL failure"}]},
         status=200,
     )
-    with pytest.raises(GraphQLError, match="Could not resolve"):
-        _client().get_org_id("nope")
-
-
-@responses.activate
-def test_http_error_after_retries_raises() -> None:
-    # 4xx that isn't in the retry list bubbles up immediately.
-    responses.add(responses.POST, GRAPHQL_URL, status=401)
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(GraphQLError, match="Some other"):
         _client().get_org_id("nope")
 
 


### PR DESCRIPTION
## Summary
- New \`plynth/errors.py\` hierarchy: \`PlynthError\` → \`AuthError\`, \`NotFoundError\`, \`NetworkError\`, \`ConfigError\`. \`GraphQLError\` is now also a \`PlynthError\`.
- \`--timeout-seconds\` CLI flag (default 30); plumbed to every \`session.post\` via \`GHESClient.request_timeout_s\`.
- Friendly error mapping: HTTP 401 → \`AuthError\`, REST 404 → \`NotFoundError\`, GraphQL \"Could not resolve\" → \`NotFoundError\`, \`requests.Timeout\` / \`ConnectionError\` → \`NetworkError\`. YAML / Pydantic validation failures during config load → \`ConfigError\`.
- \`cli.main\` wraps dispatch in \`try/except PlynthError\` → prints \`Error: {e}\` to stderr, exit code 2. Unexpected exceptions still raise so tracebacks aren't hidden in \`--verbose\`.

## What this changes for users
A token with bad scopes used to surface as a \`requests.HTTPError\` traceback; now it's:

\`\`\`
Error: Token rejected by https://ghes.example.com; verify GHES_TOKEN scopes include \`repo\` and \`project\`.
\`\`\`

A wrong org name used to surface as a \`GraphQLError(\"Could not resolve...\")\` traceback; now it's:

\`\`\`
Error: Could not resolve to an Organization with the login of 'nope' (GHES: https://ghes.example.com)
\`\`\`

A network outage used to traceback through requests internals; now it's:

\`\`\`
Error: GraphQL request to https://ghes.example.com timed out after 30s
\`\`\`

## Test plan
- [x] \`pytest -q\` → 73 passed (12 new in test_errors.py)
- [x] \`ruff check .\` clean
- [x] \`ruff format --check .\` clean
- [x] \`mypy plynth\` clean (strict, 20 source files)