### PR TITLE
PR 9: roadmap by labels and milestones

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Something isn't working as expected
-labels: bug
+labels: ["type:bug"]
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new capability or improvement
-labels: enhancement
+labels: ["type:feature"]
 ---
 
 ## Summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,10 @@ to the repository — see [SECURITY.md](SECURITY.md).
 plynth is intentionally minimal in its runtime dependencies (pydantic, pyyaml, requests).
 Before adding a dependency, consider whether the functionality can be
 implemented without it. Open an issue to discuss if unsure.
+
+## Good places to start
+
+If you are looking for a first contribution, see the
+[good-first-issue queue](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22good-first-issue%22).
+The active milestone view at <https://github.com/Declaratus/plynth/milestones>
+shows what's currently in flight and what's queued for the next release.

--- a/README.md
+++ b/README.md
@@ -238,5 +238,13 @@ Build in this order. Each step should be testable independently.
 
 ## Roadmap
 
-- v0.3.0 (in flight): github.com support via `target`, PyPI trusted publishing.
-- Post-0.3: drift detection, GitHub Action wrapper, additional backends.
+Active work and milestones: <https://github.com/Declaratus/plynth/milestones>
+
+Browse open issues by area:
+
+- [Features](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3Afeature%22)
+- [Good first issues](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22good-first-issue%22)
+- [Help wanted](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22help-wanted%22)
+
+Recent themes: github.com support and PyPI publishing (v0.3.0); drift
+detection, JSON dry-run output, and a GitHub Action wrapper (post-0.3).

--- a/docs/roadmap-setup.md
+++ b/docs/roadmap-setup.md
@@ -1,0 +1,53 @@
+# Roadmap setup (one-time, manual)
+
+This document records the `gh` commands a maintainer runs once to seed
+labels, milestones, and the v0.4.0 backlog issues. The README and
+CONTRIBUTING already point at the resulting filtered URLs; running these
+commands populates them.
+
+These steps cannot be automated in a PR — labels and milestones are repo
+state, not files. Run them after [pr/9-roadmap](#) merges.
+
+```bash
+# Labels — type:* and area:*, plus the discovery labels.
+gh label create type:feature      --color 1f883d --description "New feature"
+gh label create type:bug          --color d73a4a --description "Bug"
+gh label create type:docs         --color 0075ca --description "Documentation"
+gh label create type:chore        --color cfd3d7 --description "Tooling/refactor, no behavior change"
+gh label create area:engine       --color 5319e7 --description "engine/ module"
+gh label create area:cli          --color 5319e7 --description "cli.py"
+gh label create area:docs         --color 5319e7 --description "docs/, README"
+gh label create good-first-issue  --color 7057ff
+gh label create help-wanted       --color 008672
+
+# Milestones
+gh api -X POST repos/Declaratus/plynth/milestones -f title=v0.3.0 \
+  -f description="github.com support, PyPI release, roadmap"
+gh api -X POST repos/Declaratus/plynth/milestones -f title=v0.4.0
+gh api -X POST repos/Declaratus/plynth/milestones -f title=Backlog
+
+# Seed v0.4.0 backlog issues
+gh issue create \
+  --title "JSON dry-run output (--dry-run --format json)" \
+  --label "type:feature,area:cli,area:engine" \
+  --milestone v0.4.0 \
+  --body "Emit the ExecutionPlan as JSON when --dry-run --format json is passed, so plans can pipe into other tools."
+
+gh issue create \
+  --title "Repo creation when repo.create: true" \
+  --label "type:feature,area:engine" \
+  --milestone v0.4.0 \
+  --body "When the instance config sets repo.create: true, call POST /orgs/{org}/repos before Phase 1 instead of failing on 'repository not found'."
+
+gh issue create \
+  --title "Configurable default Status field options" \
+  --label "type:feature,area:engine" \
+  --milestone v0.4.0 \
+  --body "Allow the instance config (or template) to override which Status options are created and which is the default for new items."
+
+gh issue create \
+  --title "GHES version detection (GET /api/v3/meta)" \
+  --label "type:feature,area:engine" \
+  --milestone v0.4.0 \
+  --body "Preflight GET {target}/api/v3/meta on GHES targets to detect the installed version. Warn or refuse on mismatched feature support (e.g. createProjectV2View landed in 3.20+)."
+```


### PR DESCRIPTION
## Summary

- Replaces the bullet-list Roadmap section in the README with links to the GitHub milestone view and label-filtered issue queries (`type:feature`, `good-first-issue`, `help-wanted`).
- CONTRIBUTING gets a "Good places to start" pointer to the same queries.
- Issue templates now apply `type:bug` / `type:feature` labels so the filtered queries surface them automatically.
- `docs/roadmap-setup.md` captures the maintainer runbook for the one-time `gh` commands (labels, milestones, four v0.4.0 candidate issues). Repo state can't be created in a PR.

## Test plan

- [x] Lint + tests still green (no code changes; docs + issue template frontmatter only).
- [ ] After merge, run the commands in `docs/roadmap-setup.md` once to seed labels, milestones, and v0.4.0 backlog.