### PR TITLE
PR 8: PyPI Trusted Publishing on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install build
+        run: python -m pip install --upgrade build
+
+      - name: Build distributions
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/plynth
+    permissions:
+      id-token: write  # OIDC for Trusted Publishing — no API token required.
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **PyPI Trusted Publishing** (`.github/workflows/release.yml`) on `v*` tags.
+  Builds sdist + wheel, publishes to PyPI via OIDC (no API token in repo
+  secrets), and creates a matching GitHub Release with the artifacts
+  attached. `pipx install plynth` is now the recommended install path.
 - **`target` config field** (`plynth/models/instance.py`) replacing `ghes_url`.
   Accepts `""`, `"github.com"`, or `"https://api.github.com"` for GitHub.com,
   and `"https://<host>"` for GHES. `https://github.com` (the web host),

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ A Python CLI tool that bootstraps fully populated GitHub Projects from declarati
 
 plynth replaces a manual 30-60 minute process of copying project templates, converting draft issues to real issues, assigning milestones, replacing placeholder tokens, and wiring cross-reference dependencies. It reads a **template definition** (YAML) and an **instance config** (YAML), then orchestrates GraphQL/REST mutations to produce a project with real issues, milestones assigned, placeholders resolved, field values set, and dependency relationships wired.
 
+## Install
+
+```bash
+pipx install plynth        # recommended for use as a CLI
+pip install plynth         # for use as a library / one-shot
+```
+
+Releases are published from this repo to PyPI on every `v*` tag; GitHub
+Releases include the matching wheel + sdist.
+
 ## Configuration: target
 
 Set `target` in your instance YAML to point plynth at GitHub.com or a GHES

--- a/docs/pypi-publishing-setup.md
+++ b/docs/pypi-publishing-setup.md
@@ -1,0 +1,76 @@
+# PyPI Trusted Publishing setup (one-time, manual)
+
+The release workflow at `.github/workflows/release.yml` publishes to PyPI
+on every `v*` tag using **OIDC trusted publishing** — no API token, no
+repo secrets to leak. The OIDC binding requires two manual setup steps
+that cannot be automated from this PR. Do them **before** merging this
+PR (or at least before pushing the first `v*` tag); the first publish
+will 403 otherwise.
+
+## 1. Add the pending publisher on PyPI
+
+Log in to <https://pypi.org> with the account that will own the project
+and go to **Account → Publishing → Add a pending publisher**:
+
+| Field             | Value             |
+| ----------------- | ----------------- |
+| PyPI project name | `plynth`          |
+| Owner             | `Declaratus`      |
+| Repository name   | `plynth`          |
+| Workflow filename | `release.yml`     |
+| Environment name  | `pypi`            |
+
+> Verify the project name `plynth` is still available before doing this:
+> `pip index versions plynth` or
+> <https://pypi.org/project/plynth/>. If it's taken, fall back to
+> `plynth-cli` or `declaratus-plynth` and update the workflow's `url`
+> + `pyproject.toml`'s `name` to match.
+
+## 2. Create the GitHub environment
+
+In `Declaratus/plynth` → **Settings → Environments → New environment**.
+
+- Name (must match the workflow exactly): **`pypi`**
+- Optional: under **Deployment branches**, restrict to tag pattern
+  `v*` so only release tags can deploy.
+
+No secrets are required. OIDC handles authentication.
+
+## 3. Bump the version
+
+Update `pyproject.toml` and `plynth/__init__.py` from `0.3.0.dev0` to
+the release version (e.g. `0.3.0`). Commit on `main`. Hatchling reads
+`pyproject.toml`'s `[project] version`, so the artifact filenames
+match the tag.
+
+## 4. Dry-run the release pipeline
+
+Before tagging the real release, push an `-rc` tag to verify the binding:
+
+```bash
+git tag v0.3.0-rc1
+git push origin v0.3.0-rc1
+```
+
+Watch the **release** workflow run. All three jobs (`build`,
+`pypi-publish`, `github-release`) must turn green. If `pypi-publish`
+fails with a 403 mentioning OIDC, the pending-publisher entry from
+step 1 is missing or has a typo.
+
+After a successful dry run, yank the rc on PyPI and continue with the
+real tag:
+
+```bash
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+## 5. Verify
+
+```bash
+pipx install plynth==0.3.0
+plynth --help
+```
+
+The GitHub Release page for `v0.3.0` should have the wheel and sdist
+attached.


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` — three-job pipeline (`build` → `pypi-publish` + `github-release`) on every `v*` tag.
- Trusted Publishing via OIDC means **no API token in repo secrets**. Authentication is bound to repo + workflow filename + environment, configured by the maintainer on pypi.org and in repo Settings.
- `pypa/gh-action-pypi-publish@release/v1` stays on the moving ref (action authors' documented stable channel for security fixes); other actions use major-version tags consistent with the existing CI workflow. Dependabot already bumps both pip and github-actions weekly.
- README gains an Install section (`pipx install plynth` recommended). CHANGELOG notes the publish channel.
- `docs/pypi-publishing-setup.md` is the maintainer runbook for the user-only steps and the `v0.3.0-rc1` dry-run recipe.

## Test plan

- [x] Workflow YAML parses cleanly via PyYAML; jobs and dependency graph (`build → {pypi-publish, github-release}`) match the plan.
- [ ] User-only setup verified before merging:
  - PyPI pending publisher: project=plynth, owner=Declaratus, repo=plynth, workflow=release.yml, environment=pypi.
  - Repo Setting → Environments → `pypi` exists.
  - PyPI name `plynth` is available.
- [ ] After merge, tag `v0.3.0-rc1` to dry-run the pipeline. All three jobs must turn green; if `pypi-publish` 403s on OIDC, the binding is wrong.
- [ ] Then tag `v0.3.0`; `pipx install plynth==0.3.0` works.