### PR TITLE
chore(ci): permissions, CodeQL workflow, pip-audit (2.2 + 2.3 + 2.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -38,3 +41,28 @@ jobs:
 
       - name: Tests (pytest)
         run: pytest -q
+
+  audit:
+    name: Dependency audit (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package + dev extras
+        run: |
+          python -m pip install --upgrade pip pip-audit
+          pip install -e ".[dev]"
+
+      - name: pip-audit
+        # Fails on any vulnerability with a fix available. To suppress a
+        # specific advisory that has no upstream fix, append
+        # `--ignore-vuln <CVE-ID>` with a comment in CONTRIBUTING.md
+        # documenting the rationale and revisit date.
+        run: pip-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,21 +48,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
-      - name: Install package + dev extras
-        run: |
-          python -m pip install --upgrade pip pip-audit
-          pip install -e ".[dev]"
-
-      - name: pip-audit
-        # Fails on any vulnerability with a fix available. To suppress a
-        # specific advisory that has no upstream fix, append
-        # `--ignore-vuln <CVE-ID>` with a comment in CONTRIBUTING.md
-        # documenting the rationale and revisit date.
-        run: pip-audit
+      # Audits plynth's declared runtime dependencies in pyproject.toml,
+      # not the [dev] extras (pytest/ruff/mypy/responses) which never
+      # ship. The action runs pip-audit in isolation so its own deps
+      # don't pollute the scanned set. Fails on any reported
+      # vulnerability; to suppress a specific advisory, see the
+      # `ignore-vulns` input documented in CONTRIBUTING.md.
+      - uses: pypa/gh-action-pip-audit@v1
+        with:
+          inputs: pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Audits plynth's declared runtime dependencies in pyproject.toml,
-      # not the [dev] extras (pytest/ruff/mypy/responses) which never
-      # ship. The action runs pip-audit in isolation so its own deps
-      # don't pollute the scanned set. Fails on any reported
-      # vulnerability; to suppress a specific advisory, see the
-      # `ignore-vulns` input documented in CONTRIBUTING.md.
+      # `local: true` audits the project's runtime dependencies as
+      # declared in pyproject.toml -- not the [dev] extras (pytest/
+      # ruff/mypy/responses) which never ship to users. The action
+      # manages pip-audit in its own venv so its tooling deps don't
+      # pollute the scanned set. Fails on any reported vulnerability;
+      # to suppress a specific advisory, see the `ignore-vulns` input
+      # documented in CONTRIBUTING.md.
       - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
-          inputs: pyproject.toml
+          local: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,9 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           local: true
+          # CVE-2026-3219 is in pip itself (the runner's installed
+          # package-manager bootstrap, not a plynth runtime dependency)
+          # and has no upstream fix yet. Revisit when pip ships a patch
+          # or when GitHub-hosted runners pick up a newer pip.
+          ignore-vulns: |
+            CVE-2026-3219

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,6 @@ jobs:
       # don't pollute the scanned set. Fails on any reported
       # vulnerability; to suppress a specific advisory, see the
       # `ignore-vulns` input documented in CONTRIBUTING.md.
-      - uses: pypa/gh-action-pip-audit@v1
+      - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           inputs: pyproject.toml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 04:17 UTC catches advisories added to the CodeQL DB
+    # in quiet weeks where no PRs would otherwise trigger a scan.
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,22 @@ ruff format .
 
 Configuration lives in `pyproject.toml` under `[tool.ruff]` and `[tool.mypy]`.
 
+## Security checks
+
+CI runs two additional security gates on every PR and on push to `main`:
+
+- **CodeQL** ([.github/workflows/codeql.yml](.github/workflows/codeql.yml))
+  runs static analysis with the `security-and-quality` query suite.
+  Findings appear under the repository's **Security** tab. Also runs
+  weekly on Mondays so advisories added to the CodeQL database in
+  quiet weeks are still caught.
+- **pip-audit** (the `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml))
+  scans the resolved dependency tree for known CVEs and fails the build on
+  any vulnerability with a fix available. If a vulnerability has no
+  upstream fix and the risk is acceptable, append
+  `--ignore-vuln <CVE-ID>` to the `pip-audit` invocation with an inline
+  comment documenting the rationale and the date to revisit.
+
 ## Commit messages
 
 Use the conventional commit format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,14 @@ CI runs two additional security gates on every PR and on push to `main`:
   weekly on Mondays so advisories added to the CodeQL database in
   quiet weeks are still caught.
 - **pip-audit** (the `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml))
-  scans the resolved dependency tree for known CVEs and fails the build on
-  any vulnerability with a fix available. If a vulnerability has no
-  upstream fix and the risk is acceptable, append
-  `--ignore-vuln <CVE-ID>` to the `pip-audit` invocation with an inline
-  comment documenting the rationale and the date to revisit.
+  scans plynth's declared runtime dependencies — the
+  `[project] dependencies` block in `pyproject.toml`, not the `[dev]`
+  extras (pytest, ruff, mypy, responses, etc.) which never ship to
+  users — for known CVEs. Fails the build on any reported vulnerability,
+  including ones without an upstream fix yet. If the team accepts the
+  risk of a specific advisory, add it under the action's `ignore-vulns`
+  input in `ci.yml` with an inline comment documenting the rationale
+  and the date to revisit.
 
 ## Commit messages
 


### PR DESCRIPTION
## Summary

Self-PR C from the post-v0.3.0 security & hardening triage. Three CI security additions, all shaped to lift cleanly into the future `Declaratus/governance` spec-05 reusable `security-baseline.yml`.

### 2.2 — Workflow-level `permissions:` on ci.yml

`permissions: contents: read` at the workflow level. The `test` job only needs checkout-time read access. Mirrors the pattern release.yml already uses.

### 2.3 — Replace CodeQL Default Setup with a workflow file

New [.github/workflows/codeql.yml](https://github.com/Declaratus/plynth/blob/chore/ci-security-workflows/.github/workflows/codeql.yml). Per option B from the planning thread:

- **Status-check name preserved**: `Analyze (python)` — same as default-setup, so any branch-protection rule pinned to that check name keeps working.
- **Trigger surface widened**: push to `main`, PRs targeting `main`, and weekly cron on Mondays 04:17 UTC. Cron catches CVEs added to the CodeQL DB during quiet weeks.
- **Query suite upgraded**: `security-and-quality` (superset of default's `code-scanning` suite). May surface more findings on the first run; that's the point of the swap.
- **Tag-pinned**: `github/codeql-action@v3`, `actions/checkout@v6`. Dependabot will bump.

> [!IMPORTANT]
> **Maintainer action required before merge:** disable **CodeQL Default Setup** in Settings → Code security → Code scanning. With both enabled, the new workflow may be rejected or produce duplicate alerts. Default Setup also has to be off for advanced setup to take effect.

### 2.4 — pip-audit dependency scan

New `audit` job in ci.yml. Runs once on Python 3.12 (the test matrix would scan the same resolved env four times for no extra value).

**Re the plan's `pip-audit --strict` framing:** `--strict` in pip-audit is about packaging-metadata warnings, not severity — pip-audit has no native severity filter. So the gate is "fail on any vulnerability with a fix available." For CVEs with no upstream fix that the team accepts the risk of, the documented escape hatch is `--ignore-vuln <CVE-ID>` with an inline rationale comment.

If first-CI shows real findings, two paths: bump pyproject minimums to clear them, or `--ignore-vuln` the ones that don't apply / have no fix. I'd rather see ground truth than soft-fail-and-paper-over.

### CONTRIBUTING.md

New "Security checks" section under "Lint and type-check" describing both gates and the `--ignore-vuln` policy. Aimed at a future contributor running into a red audit job.

## Test plan

- [x] YAML parses (`yaml.safe_load` on all three workflow files)
- [x] `pytest -q` 130 passed, 2 POSIX-only tests skipped on Windows
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy plynth` clean
- [ ] CI on this branch runs the new `audit` job — surfaces real ground truth on transitive-dep CVEs
- [ ] CodeQL Default Setup disabled in repo settings before merge
- [ ] After merge, the next PR runs through both gates

## PAC migration shape

When `Declaratus/governance` spec 05 lands its `security-baseline.yml` reusable workflow, this PR's contents become a clean swap-out: delete `codeql.yml`, delete the `audit` job from `ci.yml`, and add `uses: Declaratus/governance/.github/workflows/security-baseline.yml@main` as a single called job. Both pieces are kept as standalone status checks for exactly that reason.

## Plan reference

Items 2.2, 2.3, 2.4 from `had-copilot-look-over-zippy-globe-v2.md`. With this PR landed, the only remaining items are **1.7** (Self-PR B — phase orchestrator exception scope) and **3.4** (research + SECURITY.md update for fine-grained PATs), plus the click-ops external actions (3.1, 3.3, possibly 2.7-org).