### PR TITLE
chore(engine): narrow phase orchestrator exception scope (1.7)

### DIFF
--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -10,6 +10,7 @@ import yaml
 
 from plynth.engine.graphql_client import GraphQLClient
 from plynth.engine.rest_client import RESTClient
+from plynth.errors import PlynthError
 from plynth.models.plan import ExecutionPlan, ResolvedIssue
 from plynth.models.state import (
     PHASE_1_PROJECT_AND_FIELDS,
@@ -74,10 +75,22 @@ class PhaseOrchestrator:
                 self.state.mark_phase_complete(phase_key)
                 self._save_state()
                 self.log.info(f"Completed {phase_key}")
-            except Exception as e:
+            except PlynthError as e:
+                # User-facing failure: message is already friendly. Record
+                # cleanly so a resume can show what went wrong.
                 self.state.mark_phase_error(phase_key, str(e))
                 self._save_state()
                 self.log.error(f"Failed in {phase_key}: {e}")
+                raise
+            except Exception as e:
+                # Unhandled error (programming bug, third-party library
+                # crash). Prefix the class name on the state marker so an
+                # operator inspecting the state file can tell internal
+                # failures from user-facing ones, and log with traceback
+                # since the message alone may not be enough to diagnose.
+                self.state.mark_phase_error(phase_key, f"{type(e).__name__}: {e}")
+                self._save_state()
+                self.log.exception(f"Unhandled error in {phase_key}")
                 raise
 
     def _save_state(self) -> None:

--- a/tests/test_phases_errors.py
+++ b/tests/test_phases_errors.py
@@ -1,0 +1,124 @@
+"""Tests for PhaseOrchestrator.execute() exception handling (item 1.7).
+
+The orchestrator distinguishes user-facing PlynthError subclasses from
+unexpected internal exceptions: both still write a state checkpoint
+(so resume continues to work), but the recorded marker and log shape
+differ so an operator inspecting the state file can tell which kind
+of failure happened.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_mock import MockerFixture
+
+from plynth.engine.phases import PhaseOrchestrator
+from plynth.errors import AuthError, PlynthError
+from plynth.models.state import PHASE_1_PROJECT_AND_FIELDS, StateFile
+
+
+def _make_orchestrator(
+    mocker: MockerFixture, state_path: Path
+) -> tuple[PhaseOrchestrator, StateFile]:
+    state = StateFile(target="https://ghes.example.com", org="example-org")
+    orch = PhaseOrchestrator(
+        plan=mocker.MagicMock(),
+        gql=mocker.MagicMock(),
+        rest=mocker.MagicMock(),
+        state=state,
+        state_path=state_path,
+        logger=logging.getLogger("plynth.test"),
+    )
+    return orch, state
+
+
+def test_plynth_error_is_recorded_with_clean_message_and_propagated(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    orch, state = _make_orchestrator(mocker, tmp_path / "state.yaml")
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=AuthError("Token rejected (HTTP 401)"),
+    )
+
+    with pytest.raises(AuthError, match="Token rejected"):
+        orch.execute()
+
+    status = state.phases[PHASE_1_PROJECT_AND_FIELDS]
+    assert status.completed is False
+    # PlynthError messages are already user-friendly; no class prefix added.
+    assert status.error == "Token rejected (HTTP 401)"
+
+
+def test_unhandled_exception_is_recorded_with_class_prefix_and_propagated(
+    mocker: MockerFixture, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    orch, state = _make_orchestrator(mocker, tmp_path / "state.yaml")
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=RuntimeError("library blew up"),
+    )
+
+    with (
+        caplog.at_level(logging.ERROR, logger="plynth.test"),
+        pytest.raises(RuntimeError, match="library blew up"),
+    ):
+        orch.execute()
+
+    status = state.phases[PHASE_1_PROJECT_AND_FIELDS]
+    assert status.completed is False
+    # Class name prefix lets an operator distinguish internal failures.
+    assert status.error == "RuntimeError: library blew up"
+    # log.exception was used for the unhandled path, so traceback is captured.
+    matching = [r for r in caplog.records if "Unhandled error" in r.message]
+    assert matching, "expected an 'Unhandled error' log record"
+    assert matching[0].exc_info is not None
+
+
+def test_state_checkpoint_is_persisted_before_exception_propagates(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Resume invariant: the failed phase's marker must be on disk before
+    the exception leaves execute(), or a restart will silently re-run it
+    without operator visibility into the prior failure."""
+    state_path = tmp_path / "state.yaml"
+    orch, _ = _make_orchestrator(mocker, state_path)
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=PlynthError("network fell over"),
+    )
+
+    with pytest.raises(PlynthError):
+        orch.execute()
+
+    assert state_path.exists()
+    on_disk = StateFile.model_validate(yaml.safe_load(state_path.read_text(encoding="utf-8")))
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].completed is False
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].error == "network fell over"
+
+
+def test_unhandled_exception_checkpoint_also_persisted(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Same checkpoint guarantee for the broad-Exception branch — that's
+    the whole point of writing state before re-raising in both branches."""
+    state_path = tmp_path / "state.yaml"
+    orch, _ = _make_orchestrator(mocker, state_path)
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=ValueError("bad data"),
+    )
+
+    with pytest.raises(ValueError):
+        orch.execute()
+
+    on_disk = StateFile.model_validate(yaml.safe_load(state_path.read_text(encoding="utf-8")))
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].error == "ValueError: bad data"


### PR DESCRIPTION
## Summary

Self-PR B from the post-v0.3.0 hardening triage. The orchestrator's broad `except Exception` is split into two branches that both still write a state checkpoint and re-raise — preserving resume semantics — but distinguish user-facing failures from unexpected internal ones on the state file and in the log.

### Before

```python
except Exception as e:
    self.state.mark_phase_error(phase_key, str(e))
    self._save_state()
    self.log.error(f"Failed in {phase_key}: {e}")
    raise
```

### After

```python
except PlynthError as e:
    # User-facing: message is already friendly.
    self.state.mark_phase_error(phase_key, str(e))
    self._save_state()
    self.log.error(f"Failed in {phase_key}: {e}")
    raise
except Exception as e:
    # Programming bug or third-party crash. Class-prefix the marker so
    # an operator can tell internal failures from user-facing ones,
    # and log with traceback since the message alone may not be enough.
    self.state.mark_phase_error(phase_key, f"{type(e).__name__}: {e}")
    self._save_state()
    self.log.exception(f"Unhandled error in {phase_key}")
    raise
```

## Decisions

- **`KeyboardInterrupt` is intentionally not caught.** It's a `BaseException`, and the existing per-phase checkpoint-on-success means a Ctrl+C mid-phase leaves the previous phase's complete checkpoint, which is already a consistent resume point. Adding a `BaseException` handler would risk swallowing `SystemExit` for marginal benefit.
- **State-file wire format.** Existing `error: "Token rejected"` entries stay unchanged for `PlynthError` paths. New `RuntimeError: ...` prefix only appears on the unhandled branch, which is by definition a path that wasn't tripping in production. No migration needed.
- **CLI top-level handler.** `cli.main`'s existing `except PlynthError` catch still works: the orchestrator re-raises `PlynthError` unchanged. Unhandled exceptions propagate as Python tracebacks (the previous behaviour).

## Test plan

- [x] `pytest -q` 134 passed, 2 POSIX-only tests skipped on Windows (no regression: e2e happy-path and resume-noop tests still pass)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy plynth` clean
- [x] New `tests/test_phases_errors.py` covers:
  - PlynthError branch records a clean message and re-raises the original type
  - Unhandled-Exception branch records a `<ClassName>: <msg>` prefix and re-raises
  - State checkpoint is on disk before the exception leaves `execute()` (both branches)
  - `log.exception` was used in the unhandled branch (caplog records carry `exc_info`)
- [ ] Manual smoke: deliberate `KeyboardInterrupt` mid-phase, verify the prior phase's checkpoint on disk is parseable

## Plan reference

Item 1.7 from `had-copilot-look-over-zippy-globe-v2.md`. With this PR landed, only **3.4** (fine-grained PAT research + SECURITY.md doc update) remains from the self-PR queue, plus the click-ops external actions (3.1 branch protection, 3.3 GHAS at org level).