### PR TITLE
docs(security): document fine-grained PAT permissions (3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **SECURITY.md** now documents the exact PAT permissions plynth needs.
+  A fine-grained PAT with repository *Issues: Read and write* +
+  organization *Projects: Read and write* is the recommended shape on
+  github.com. The same shape is intended to apply to GHES 3.19+, but
+  GHES 3.19's fine-grained-PAT permissions reference does not currently
+  document the org-level Projects permission for the ProjectV2 GraphQL
+  mutations — verify against your instance before relying on it, or
+  fall back to a classic PAT with `repo` + `project` scopes or a
+  GitHub App installation token. GitHub App authentication (both
+  installation tokens and user access tokens) is documented as a
+  bring-your-own-token path; the CLI does not bootstrap either flow
+  itself.
+
 ---
 
 ## [0.3.0] — 2026-05-02

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ target: https://api.github.com           # equivalent
 target: https://ghes.example.com         # GHES — REST under /api/v3
 ```
 
-Authenticate with `PLYNTH_TOKEN=ghp_...` (or `--token`). `GHES_TOKEN` is
+Authenticate with `PLYNTH_TOKEN` (or `--token`). On github.com, a
+fine-grained PAT with repository *Issues: Read and write* + organization
+*Projects: Read and write* is the recommended shape; on GHES 3.19+,
+the Issues permissions are documented but the ProjectV2 permission
+story is less certain (see SECURITY.md for the caveat). Classic PATs
+with `repo` + `project` scopes work end-to-end on either target. Full
+breakdown in [SECURITY.md](SECURITY.md#token-handling). `GHES_TOKEN` is
 accepted for one release with a deprecation warning.
 
 ## Technology stack

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,20 @@
 
 ## Token handling
 
-plynth authenticates against the GitHub API with a Personal Access Token.
-A fine-grained PAT is the recommended shape on both target types.
+plynth accepts any GitHub API bearer token via `PLYNTH_TOKEN` (or
+`--token`). Three token types are supported, in order of preference
+for new setups: fine-grained PAT (recommended), classic PAT, and
+GitHub App tokens (installation or user access). Each is detailed
+below.
 
 ### Fine-grained PAT — recommended
 
 Fine-grained PATs scope access to specific repositories and one
-organization, and are the preferred token type for new setups. They are
-supported on both github.com and GitHub Enterprise Server 3.19+ (the
-GHES versions plynth targets), so the same permission set applies to
-both.
+organization, and are the preferred token type for new setups. The
+permission set below is documented end-to-end for github.com targets.
+GHES 3.19 supports fine-grained PATs but has a documentation gap on
+the org-level *Projects* permission — see the GHES caveat below
+before assuming this works the same way against a GHES instance.
 
 Create the token at:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,88 @@
 
 ## Token handling
 
-plynth requires a GitHub Personal Access Token (PAT) with `repo` and `project` scopes.
+plynth authenticates against the GitHub API with a Personal Access Token.
+A fine-grained PAT is the recommended shape on both target types.
+
+### Fine-grained PAT — recommended
+
+Fine-grained PATs scope access to specific repositories and one
+organization, and are the preferred token type for new setups. They are
+supported on both github.com and GitHub Enterprise Server 3.19+ (the
+GHES versions plynth targets), so the same permission set applies to
+both.
+
+Create the token at:
+
+- **github.com:** <https://github.com/settings/personal-access-tokens/new>
+- **GHES:** `https://<your-ghes-host>/settings/personal-access-tokens/new`
+
+Configure with:
+
+- **Resource owner:** the GitHub organization that will own the project.
+- **Repository access:** *Only select repositories* → select the repo
+  named in the instance config's `repo.name`.
+- **Repository permissions:**
+  - **Issues:** *Read and write* — covers `createIssue`, `updateIssue`
+    (body rewrites in Phase 5), `addBlockedBy` (dependency edges), and
+    the REST `POST /repos/{owner}/{repo}/milestones` endpoint, which
+    lives under the Issues permission scope.
+  - **Metadata:** *Read-only* — required for any repository access and
+    auto-granted alongside the other permissions.
+- **Organization permissions:**
+  - **Projects:** *Read and write* — covers `createProjectV2`,
+    `createProjectV2Field`, the project-fields query, `addProjectV2ItemById`,
+    and `updateProjectV2ItemFieldValue`. Projects are owned at the
+    organization level, so this permission lives in the *Organization*
+    section, not under the repository.
+
+No other permissions are required. Granting `Contents`, `Pull requests`,
+or org-wide repo access broadens the blast radius of a leaked token
+without enabling any plynth feature.
+
+> **GHES 3.19 caveat.** GHES 3.19 exposes the ProjectV2 GraphQL
+> mutations, but the required fine-grained PAT permission for
+> ProjectV2 mutations is not documented in the GHES 3.19 fine-grained
+> PAT permissions reference. On github.com, the equivalent permission
+> is documented as an organization-level *Projects* permission, but
+> that section is absent from the GHES 3.19 page. For GHES 3.19,
+> verify fine-grained PAT behavior against the target instance; if it
+> fails or the permission is unavailable in the UI, use a classic PAT
+> with `project` scope (next section) or a GitHub App installation
+> token.
+
+### Classic PAT — supported alternative
+
+Classic PATs with `repo` + `project` scopes authenticate plynth against
+either target type. They grant much broader access than plynth's
+operations call for, so prefer a fine-grained PAT in new setups against
+github.com. Pick a classic PAT when:
+
+- Your GHES instance has fine-grained PATs disabled by admin policy.
+- You want a permission story that is documented end-to-end on GHES
+  3.19 today (see the caveat above on ProjectV2).
+- You're on an older GHES release where fine-grained PATs are not yet GA.
+
+### GitHub Apps
+
+GitHub App authentication is supported on both github.com and GHES
+3.19+, in two flavours that plynth treats identically:
+
+- **Installation tokens (IAT)** — minted server-side from the App's
+  private key. Suitable for automation. This is also the documented
+  fallback when a fine-grained PAT can't grant the *Projects*
+  permission on a GHES 3.19 instance (see the caveat above).
+- **User access tokens (UAT)** — minted via the OAuth user-consent
+  flow.
+
+The plynth CLI does not currently bootstrap either flow itself, so
+this is a "bring your own token" path rather than an integrated one.
+If you have an external flow that produces a token of either type,
+plynth will accept it via `PLYNTH_TOKEN`. The App's installation
+permissions must match the fine-grained PAT permission set above
+(repository *Issues* + *Metadata*, organization *Projects*).
+
+### Operational handling
 
 **Do:**
 - Pass the token via the `PLYNTH_TOKEN` environment variable.

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -10,6 +10,7 @@ import yaml
 
 from plynth.engine.graphql_client import GraphQLClient
 from plynth.engine.rest_client import RESTClient
+from plynth.errors import PlynthError
 from plynth.models.plan import ExecutionPlan, ResolvedIssue
 from plynth.models.state import (
     PHASE_1_PROJECT_AND_FIELDS,
@@ -74,10 +75,22 @@ class PhaseOrchestrator:
                 self.state.mark_phase_complete(phase_key)
                 self._save_state()
                 self.log.info(f"Completed {phase_key}")
-            except Exception as e:
+            except PlynthError as e:
+                # User-facing failure: message is already friendly. Record
+                # cleanly so a resume can show what went wrong.
                 self.state.mark_phase_error(phase_key, str(e))
                 self._save_state()
                 self.log.error(f"Failed in {phase_key}: {e}")
+                raise
+            except Exception as e:
+                # Unhandled error (programming bug, third-party library
+                # crash). Prefix the class name on the state marker so an
+                # operator inspecting the state file can tell internal
+                # failures from user-facing ones, and log with traceback
+                # since the message alone may not be enough to diagnose.
+                self.state.mark_phase_error(phase_key, f"{type(e).__name__}: {e}")
+                self._save_state()
+                self.log.exception(f"Unhandled error in {phase_key}")
                 raise
 
     def _save_state(self) -> None:

--- a/tests/test_phases_errors.py
+++ b/tests/test_phases_errors.py
@@ -1,0 +1,124 @@
+"""Tests for PhaseOrchestrator.execute() exception handling (item 1.7).
+
+The orchestrator distinguishes user-facing PlynthError subclasses from
+unexpected internal exceptions: both still write a state checkpoint
+(so resume continues to work), but the recorded marker and log shape
+differ so an operator inspecting the state file can tell which kind
+of failure happened.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_mock import MockerFixture
+
+from plynth.engine.phases import PhaseOrchestrator
+from plynth.errors import AuthError, PlynthError
+from plynth.models.state import PHASE_1_PROJECT_AND_FIELDS, StateFile
+
+
+def _make_orchestrator(
+    mocker: MockerFixture, state_path: Path
+) -> tuple[PhaseOrchestrator, StateFile]:
+    state = StateFile(target="https://ghes.example.com", org="example-org")
+    orch = PhaseOrchestrator(
+        plan=mocker.MagicMock(),
+        gql=mocker.MagicMock(),
+        rest=mocker.MagicMock(),
+        state=state,
+        state_path=state_path,
+        logger=logging.getLogger("plynth.test"),
+    )
+    return orch, state
+
+
+def test_plynth_error_is_recorded_with_clean_message_and_propagated(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    orch, state = _make_orchestrator(mocker, tmp_path / "state.yaml")
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=AuthError("Token rejected (HTTP 401)"),
+    )
+
+    with pytest.raises(AuthError, match="Token rejected"):
+        orch.execute()
+
+    status = state.phases[PHASE_1_PROJECT_AND_FIELDS]
+    assert status.completed is False
+    # PlynthError messages are already user-friendly; no class prefix added.
+    assert status.error == "Token rejected (HTTP 401)"
+
+
+def test_unhandled_exception_is_recorded_with_class_prefix_and_propagated(
+    mocker: MockerFixture, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    orch, state = _make_orchestrator(mocker, tmp_path / "state.yaml")
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=RuntimeError("library blew up"),
+    )
+
+    with (
+        caplog.at_level(logging.ERROR, logger="plynth.test"),
+        pytest.raises(RuntimeError, match="library blew up"),
+    ):
+        orch.execute()
+
+    status = state.phases[PHASE_1_PROJECT_AND_FIELDS]
+    assert status.completed is False
+    # Class name prefix lets an operator distinguish internal failures.
+    assert status.error == "RuntimeError: library blew up"
+    # log.exception was used for the unhandled path, so traceback is captured.
+    matching = [r for r in caplog.records if "Unhandled error" in r.message]
+    assert matching, "expected an 'Unhandled error' log record"
+    assert matching[0].exc_info is not None
+
+
+def test_state_checkpoint_is_persisted_before_exception_propagates(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Resume invariant: the failed phase's marker must be on disk before
+    the exception leaves execute(), or a restart will silently re-run it
+    without operator visibility into the prior failure."""
+    state_path = tmp_path / "state.yaml"
+    orch, _ = _make_orchestrator(mocker, state_path)
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=PlynthError("network fell over"),
+    )
+
+    with pytest.raises(PlynthError):
+        orch.execute()
+
+    assert state_path.exists()
+    on_disk = StateFile.model_validate(yaml.safe_load(state_path.read_text(encoding="utf-8")))
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].completed is False
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].error == "network fell over"
+
+
+def test_unhandled_exception_checkpoint_also_persisted(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Same checkpoint guarantee for the broad-Exception branch — that's
+    the whole point of writing state before re-raising in both branches."""
+    state_path = tmp_path / "state.yaml"
+    orch, _ = _make_orchestrator(mocker, state_path)
+    mocker.patch.object(
+        orch,
+        "phase_1_create_project_and_fields",
+        side_effect=ValueError("bad data"),
+    )
+
+    with pytest.raises(ValueError):
+        orch.execute()
+
+    on_disk = StateFile.model_validate(yaml.safe_load(state_path.read_text(encoding="utf-8")))
+    assert on_disk.phases[PHASE_1_PROJECT_AND_FIELDS].error == "ValueError: bad data"


### PR DESCRIPTION
## Summary

Self research+doc PR from the post-v0.3.0 hardening triage. SECURITY.md now documents the exact PAT permissions plynth needs, with a worked-out story for both target types and a third option (GitHub Apps) noted for completeness.

## Recommended shape — github.com

A fine-grained PAT scoped to the org that owns the project, with:

| Scope | Permission | Level | Covers |
|---|---|---|---|
| Repository | **Issues** | Read and write | `createIssue`, `updateIssue` (body rewrites in Phase 5), `addBlockedBy` (dependency edges), and the milestone REST POST that lives under Issues |
| Repository | **Metadata** | Read-only | Auto-granted; required for any repo access |
| Organization | **Projects** | Read and write | `createProjectV2`, `createProjectV2Field`, the project-fields query, `addProjectV2ItemById`, `updateProjectV2ItemFieldValue` |

Permission set was derived by mapping every GraphQL/REST operation in [plynth/engine/{phases,graphql_client,rest_client}.py](https://github.com/Declaratus/plynth/tree/main/plynth/engine) to its corresponding fine-grained-PAT permission, cross-referenced against [the github.com fine-grained-PAT permissions reference](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28).

## GHES 3.19 caveat

GHES 3.19 exposes the ProjectV2 GraphQL mutations (28 of them, all the ones plynth uses), but the required fine-grained-PAT permission for those mutations is **not** documented in the [GHES 3.19 fine-grained-PAT permissions reference](https://docs.github.com/en/enterprise-server@3.19/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28). The org-level *Projects* permission section that exists on the github.com page is absent from the GHES 3.19 mirror.

For GHES 3.19, SECURITY.md instructs users to verify fine-grained PAT behaviour against their target instance. If the Projects permission is unavailable in the UI or the mutations 403, the documented fallbacks are:

- A **classic PAT** with `repo` + `project` scopes (longstanding, end-to-end documented).
- A **GitHub App installation token** with installation permissions matching the fine-grained-PAT shape above.

## GitHub Apps

Documented as a bring-your-own-token path. The CLI doesn't bootstrap either flow today (no OAuth, no JWT-to-IAT exchange), but `PLYNTH_TOKEN` accepts a token of either type if you have an external flow that produces one.

## Test plan

- [x] `pytest -q` 134 passed, 2 POSIX-only tests skipped on Windows
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy plynth` clean (docs-only PR but verified nothing else broke)
- [ ] **Maintainer action — real-account validation** before relying on these claims for v0.4.0 release notes:
  - Mint a fine-grained PAT against a github.com test org with the documented permission set, run `plynth create` against a sandbox repo, confirm Phases 1–7 all complete.
  - If you have a GHES 3.19 sandbox: try the same fine-grained PAT shape and report whether the Projects permission is available in the UI / whether the mutations 403. Either outcome lets us tighten the GHES caveat.

## Plan reference

Item 3.4 from `had-copilot-look-over-zippy-globe-v2.md`. With this PR, all five self-PRs from the plan are now open or merged. Remaining: click-ops external actions (3.1 branch protection, 3.3 GHAS at org level, optional 2.7 org-level secret scanning) and the 4 Dependabot PRs (#16-19) you flagged to circle back.

## PAC connection

This research also resolves spec 01's open question 2 ("the GitHub App vs. fine-grained PAT story for the apply workflow's auth"). The recommended shape here — plus the GHES caveat — is the same one the future `Declaratus/governance/RUNBOOKS/` apply-workflow doc will need to point at, modulo the additional `Contents: Write` an apply workflow would need to push ruleset updates back to repos.