### PR TITLE
chore: gitignore .import/ for imported feedback artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 .env
 .venv/
 
+# Imported feedback / context (not source)
+.import/
+
 # Credentials & secrets
 secrets.yaml
 secrets.yml


### PR DESCRIPTION
Adds `.import/` to .gitignore so imported feedback documents and run logs (e.g. results from running plynth against a real GHES project) don't accidentally get pushed.

No code change.