### PR TITLE
docs(security): confirm GHES FGPAT path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   installation tokens and user access tokens) is documented as a
   bring-your-own-token path; the CLI does not bootstrap either flow
   itself.
+- **SECURITY.md** now notes that the documented fine-grained PAT
+  permission set was confirmed against GHES 3.19 in 2026-05.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,15 @@ without enabling any plynth feature.
 > with `project` scope (next section) or a GitHub App installation
 > token.
 
+#### Confirmed against GHES 3.19 (2026-05)
+
+A fine-grained PAT with repository *Issues: Read and write* and
+organization *Projects: Read and write* drove a full plynth bootstrap
+end-to-end: project, fields, milestones, issues, project items,
+dependencies, and state file. The permission set documented in
+[PR #39](https://github.com/Declaratus/plynth/pull/39) is the path that
+worked.
+
 ### Classic PAT — supported alternative
 
 Classic PATs with `repo` + `project` scopes authenticate plynth against


### PR DESCRIPTION
## Summary

Fixes #46. Adds the confirmed GHES 3.19 fine-grained PAT note to SECURITY.md and records the docs change in CHANGELOG.md.

## Changes

- Added a confirmed-against-GHES subsection under the existing caveat.
- Linked the permission set back to PR #39.
- Added an Unreleased changelog entry.

## Testing

- [ ] New unit tests added (`tests/`)
- [x] Existing tests pass (`pytest -q`)
- [ ] Tested manually against a live instance (describe below)
- [x] No testable behaviour change (docs, config, refactor)

Docs-only change. I also ran `ruff check .`, `ruff format --check .`, and `mypy plynth`.

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy plynth` passes
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No `--token` flag with a literal value committed in any YAML, shell script, or workflow file
- [x] No `PLYNTH_TOKEN` value committed (only references such as `${{ secrets.PLYNTH_TOKEN }}` are OK)