### PR TITLE
feat(template): rich field options, defaults, reconciliation stub (M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   declare `color`, `description`, `default`, `aliases`, and `deprecated` as
   an object instead of a plain string. Plain strings still work; the two
   forms can mix in the same field. See `docs/options.md`. A new
-  `allow_unknown_values: false` field-level guard rejects drift starters at
-  parse time. Out-of-set colors downgrade to GRAY at plan time with a
-  warning rather than failing the run.
+  `allow_unknown_values: false` field-level guard (default) rejects any
+  issue, template default, or instance override that references a value
+  not declared in the field's options. Enforced at plan time so drift
+  fails the run cleanly instead of silently skipping in Phase 4. Set
+  `allow_unknown_values: true` to opt out per field. Out-of-set colors
+  downgrade to GRAY at plan time with a warning rather than failing the
+  run.
 - **Template-level defaults** (#43). New optional `defaults.fields` section
   on the template applies field values to every issue unless overridden.
   Precedence: per-issue value > template default > engine fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Rich field option objects** (#42). Single-select field options can now
+  declare `color`, `description`, `default`, `aliases`, and `deprecated` as
+  an object instead of a plain string. Plain strings still work; the two
+  forms can mix in the same field. See `docs/options.md`. A new
+  `allow_unknown_values: false` field-level guard rejects drift starters at
+  parse time. Out-of-set colors downgrade to GRAY at plan time with a
+  warning rather than failing the run.
+- **Template-level defaults** (#43). New optional `defaults.fields` section
+  on the template applies field values to every issue unless overridden.
+  Precedence: per-issue value > template default > engine fallback.
+  Instance `field_overrides` retain top precedence. Labels deferred until
+  the labels-and-issue-types feature lands.
+- **`reconciliation:` namespace reserved** (#44). New optional
+  `reconciliation` block on the template carries `mode`
+  (`none` | `report_only`) and `verify_after_apply`. Today only
+  `mode: none` is honored; the namespace is reserved now because every
+  model uses `extra="forbid"`, so adding fields later breaks anyone who
+  already put a placeholder block in. `verify_after_apply` will be wired
+  to the verify subcommand when it ships.
+
 ### Changed
 
 - **SECURITY.md** now documents the exact PAT permissions plynth needs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   issue, template default, or instance override that references a value
   not declared in the field's options. Enforced at plan time so drift
   fails the run cleanly instead of silently skipping in Phase 4. Set
-  `allow_unknown_values: true` to opt out per field. Out-of-set colors
-  downgrade to GRAY at plan time with a warning rather than failing the
-  run.
+  `allow_unknown_values: true` to opt out per field. `color` is validated
+  against the GHES 3.19 ProjectV2 color set at template parse time;
+  options that omit `color` render as GRAY.
 - **Template-level defaults** (#43). New optional `defaults.fields` section
   on the template applies field values to every issue unless overridden.
   Precedence: per-issue value > template default > engine fallback.

--- a/docs/example-template.yaml
+++ b/docs/example-template.yaml
@@ -81,10 +81,18 @@ fields:
   - id: priority
     name: "Priority"
     type: single_select
+    # Rich option objects carry color/description/default at bootstrap time.
+    # Plain strings still work (see workstream above) — they get GRAY by default.
+    # See docs/options.md for the full option schema.
     options:
-      - "P1 -- Critical Path"
-      - "P2 -- Important"
-      - "P3 -- When Capacity Allows"
+      - value: "P1 -- Critical Path"
+        color: RED
+        description: "Blocks downstream milestones if it slips."
+      - value: "P2 -- Important"
+        color: YELLOW
+        description: "Drive to closure within the milestone."
+        default: true
+      - "P3 -- When Capacity Allows"   # legacy string form, still valid
 
   - id: owner
     name: "Owner"

--- a/docs/options.md
+++ b/docs/options.md
@@ -33,13 +33,13 @@ fields:
         color: YELLOW
         description: "Drive to closure within the milestone."
         default: true
-      - value: "P3"          # mix and match: this one stays a plain string
+      - "P3"                 # mix and match: legacy string form is still valid
 ```
 
 | key | type | default | notes |
 |-----|------|---------|-------|
 | `value` | string (max 100) | required | Display name on the board. Placeholders resolved at plan time. |
-| `color` | enum | omitted (GRAY) | One of GRAY, BLUE, YELLOW, RED, PURPLE, GREEN, ORANGE, PINK. Out-of-set values downgrade to GRAY at plan time with a warning. |
+| `color` | enum | omitted (rendered GRAY) | One of GRAY, BLUE, YELLOW, RED, PURPLE, GREEN, ORANGE, PINK. Anything else fails template validation; add the value to `OptionColor` if a future GHES version introduces a new color. |
 | `description` | string (max 2000) | "" | Tooltip text shown on hover in the project board. |
 | `default` | bool | false | At most one option per field may be `default: true`. Reserved for future "set on item creation" behavior; currently informational. |
 | `aliases` | list[string] | [] | Reserved for future option-rename reconciliation. Currently informational. |

--- a/docs/options.md
+++ b/docs/options.md
@@ -47,7 +47,7 @@ fields:
 
 ### Field-level guards
 
-`allow_unknown_values: false` (the default) rejects any issue that references a field option not declared in `options`. Drift in field option taxonomy starts when one issue silently introduces a new value, so the strict default protects views and filters that group on the field. Set to `true` only when the field is genuinely free-form.
+`allow_unknown_values: false` (the default) rejects any issue, template default, or instance override that references a field option value not declared in `options`. Enforcement happens at plan time, so drift fails the run cleanly instead of silently skipping later. Drift in field option taxonomy starts when one issue silently introduces a new value, so the strict default protects views and filters that group on the field. Set `allow_unknown_values: true` only when the field is genuinely free-form (e.g., notes, ad-hoc tags).
 
 ## Best practices for option colors
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,78 @@
+# Field options reference
+
+Single-select field options can be declared in two forms. Both work in the same template; mix as convenient.
+
+## Legacy string form
+
+```yaml
+fields:
+  - id: workstream
+    name: "Workstream"
+    type: single_select
+    options:
+      - "Documentation"
+      - "Infrastructure"
+      - "Operations"
+```
+
+Each option lands on the project board as GRAY with no description. Equivalent to the rich form below with only `value` set.
+
+## Rich object form
+
+```yaml
+fields:
+  - id: priority
+    name: "Priority"
+    type: single_select
+    allow_unknown_values: false
+    options:
+      - value: "P1"
+        color: RED
+        description: "Blocks downstream milestones if it slips."
+      - value: "P2"
+        color: YELLOW
+        description: "Drive to closure within the milestone."
+        default: true
+      - value: "P3"          # mix and match: this one stays a plain string
+```
+
+| key | type | default | notes |
+|-----|------|---------|-------|
+| `value` | string (max 100) | required | Display name on the board. Placeholders resolved at plan time. |
+| `color` | enum | omitted (GRAY) | One of GRAY, BLUE, YELLOW, RED, PURPLE, GREEN, ORANGE, PINK. Out-of-set values downgrade to GRAY at plan time with a warning. |
+| `description` | string (max 2000) | "" | Tooltip text shown on hover in the project board. |
+| `default` | bool | false | At most one option per field may be `default: true`. Reserved for future "set on item creation" behavior; currently informational. |
+| `aliases` | list[string] | [] | Reserved for future option-rename reconciliation. Currently informational. |
+| `deprecated` | bool | false | Marks an option as legacy. Currently informational. |
+
+### Field-level guards
+
+`allow_unknown_values: false` (the default) rejects any issue that references a field option not declared in `options`. Drift in field option taxonomy starts when one issue silently introduces a new value, so the strict default protects views and filters that group on the field. Set to `true` only when the field is genuinely free-form.
+
+## Best practices for option colors
+
+Pick colors per field as a categorical scale. Avoid two adjacent option values sharing a color, and reuse semantics across fields where possible:
+
+- **red** — critical / blocked / regression
+- **yellow** — in progress / attention
+- **green** — approved / done
+- **gray** — neutral / N/A / not yet triaged
+- **blue / purple / orange / pink** — categorical distinctions where the semantics above don't apply
+
+A worked example for a Status field:
+
+```yaml
+status:
+  - { value: "Backlog",     color: GRAY }
+  - { value: "Ready",       color: BLUE }
+  - { value: "In Progress", color: YELLOW }
+  - { value: "Blocked",     color: RED }
+  - { value: "In Review",   color: PURPLE }
+  - { value: "Done",        color: GREEN }
+```
+
+## Critical: option mutations are full-list replacements
+
+The ProjectV2 GraphQL mutation that creates or updates field options replaces the full options list. Any option omitted from the input is **deleted**, along with all option-id-bearing field values on items that pointed to it.
+
+plynth's bootstrap path always passes the full declared list, so this is safe at create time. Any future tooling that updates field options on an existing project (reconciliation, rename, deprecation) must read existing options first, merge changes into the full list, then write. Never pass a partial list.

--- a/docs/plynth-design-spec.md
+++ b/docs/plynth-design-spec.md
@@ -129,9 +129,16 @@ fields:
   - id: priority
     name: "Priority"
     type: single_select
+    # Options can be plain strings (legacy) or rich objects with color,
+    # description, default, aliases, and deprecated. See docs/options.md
+    # for the full schema. Mixed forms are allowed in the same field.
     options:
-      - "P1 -- Critical Path"
-      - "P2 -- Important"
+      - value: "P1 -- Critical Path"
+        color: RED
+        description: "Blocks downstream milestones if it slips."
+      - value: "P2 -- Important"
+        color: YELLOW
+        default: true
       - "P3 -- When Capacity Allows"
 
   - id: owner
@@ -141,6 +148,26 @@ fields:
       - "{TEAM}"         # Resolved to "Platform Engineering" (or whatever TEAM is)
       - "Platform"
       - "External"
+
+# ─── Defaults ───────────────────────────────────────────────────
+# Template-level defaults applied to every issue unless overridden.
+# Precedence (lowest to highest): engine fallback, template defaults,
+# per-issue values, instance.field_overrides. Last writer wins per key.
+# Labels are intentionally deferred until the labels-and-issue-types
+# feature lands.
+defaults:
+  fields:
+    workstream: "Operations"
+
+# ─── Reconciliation (reserved namespace) ─────────────────────────
+# Reserved for the verify subcommand and the companion reconcile
+# skill. Today only `mode: none` is honored. `report_only` parses
+# but is treated identically to `none` until reconciliation ships.
+# Reserving the namespace now avoids a schema break later because
+# every model uses extra="forbid".
+reconciliation:
+  mode: none
+  verify_after_apply: false
 
 # ─── Milestones ─────────────────────────────────────────────────
 # Created as GitHub repository milestones (REST, not GraphQL).

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -106,6 +106,12 @@ class GraphQLClient:
         )
         return data["createProjectV2"]["projectV2"]
 
+    # CRITICAL: ProjectV2 single-select option mutations (this method on
+    # create, plus any future updateProjectV2Field-style call) replace the
+    # full options list. Any option omitted from the input is DELETED, along
+    # with all option_id-bearing field values on items that pointed to it.
+    # Reconciliation must read-modify-write: read existing options, merge
+    # changes into the full list, then write. Never pass a partial list.
     def create_field(
         self,
         project_id: str,

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -127,7 +127,8 @@ class PhaseOrchestrator:
         for field in self.plan.fields:
             if field.type == "single_select":
                 options = [
-                    {"name": opt, "color": "GRAY", "description": ""} for opt in field.options
+                    {"name": opt.value, "color": opt.color, "description": opt.description}
+                    for opt in field.options
                 ]
                 self.gql.create_field(
                     project_id=self.state.project.node_id,

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -7,10 +7,11 @@ from plynth.models.instance import InstanceConfig
 from plynth.models.plan import (
     ExecutionPlan,
     ResolvedField,
+    ResolvedFieldOption,
     ResolvedIssue,
     ResolvedMilestone,
 )
-from plynth.models.template import TemplateDefinition
+from plynth.models.template import KNOWN_OPTION_COLORS, TemplateDefinition
 
 # Matches {PREFIX}-### patterns in issue bodies (cross-references).
 _CROSSREF_RE = re.compile(r"\{PREFIX\}-(\d{3})")
@@ -107,8 +108,12 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
     # ── Step 4 & 5: Resolve placeholders + trim deps ──────────────
     resolved_issues: list[ResolvedIssue] = []
     for issue in effective_issues:
-        # Apply field overrides before resolution
-        fields = dict(issue.fields)
+        # Field precedence: template defaults → per-issue → instance overrides.
+        # Last writer wins per key. Instance overrides remain top precedence so
+        # operators can still patch a single instance without editing the template.
+        fields: dict[str, str] = {}
+        fields.update(template.defaults.fields)
+        fields.update(issue.fields)
         if issue.template_id in instance.field_overrides:
             fields.update(instance.field_overrides[issue.template_id])
 
@@ -152,15 +157,30 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
         )
 
     # ── Step 6: Resolve field options ──────────────────────────────
-    resolved_field_defs = [
-        ResolvedField(
-            id=f.id,
-            name=f.name,
-            type=f.type,
-            options=[resolve_placeholders(opt, values) for opt in f.options],
-        )
-        for f in template.fields
-    ]
+    # Pre-flight option colors against the GHES floor. Out-of-set colors get
+    # downgraded to GRAY with a warning so the run completes against any
+    # supported version. Templates authored against newer GHES that adds
+    # colors will degrade gracefully on the 3.19 floor.
+    resolved_field_defs: list[ResolvedField] = []
+    for f in template.fields:
+        opts: list[ResolvedFieldOption] = []
+        for opt in f.options:
+            color = opt.color
+            if color is not None and color not in KNOWN_OPTION_COLORS:
+                warnings.append(
+                    f"Field '{f.id}' option '{opt.value}': color '{color}' not in "
+                    f"the supported set {sorted(KNOWN_OPTION_COLORS)}; using GRAY"
+                )
+                color = "GRAY"
+            opts.append(
+                ResolvedFieldOption(
+                    value=resolve_placeholders(opt.value, values),
+                    color=color or "GRAY",
+                    description=resolve_placeholders(opt.description, values),
+                    default=opt.default,
+                )
+            )
+        resolved_field_defs.append(ResolvedField(id=f.id, name=f.name, type=f.type, options=opts))
 
     # ── Step 8: Resolve project description ({DATE}) ──────────────
     project_desc = instance.project.description.replace("{DATE}", date.today().isoformat())
@@ -243,7 +263,9 @@ def format_dry_run(ep: ExecutionPlan) -> str:
     # Fields
     w(f"Fields ({len(ep.fields)}):")
     for f in ep.fields:
-        w(f"  {f.id}: {f.name} [{f.type}] ({len(f.options)} options)")
+        n_colored = sum(1 for o in f.options if o.color != "GRAY")
+        suffix = f", {n_colored} colored" if n_colored else ""
+        w(f"  {f.id}: {f.name} [{f.type}] ({len(f.options)} options{suffix})")
     w("")
 
     # Warnings

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -182,6 +182,29 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
             )
         resolved_field_defs.append(ResolvedField(id=f.id, name=f.name, type=f.type, options=opts))
 
+    # ── Step 7: Enforce allow_unknown_values guard ─────────────────
+    # For single-select fields where allow_unknown_values is false (the
+    # default), every resolved issue field value must match a declared
+    # option. Catching this at plan time turns drift into a hard error
+    # instead of a silent runtime skip in Phase 4.
+    strict_field_options: dict[str, set[str]] = {}
+    for tmpl_field, rf in zip(template.fields, resolved_field_defs):
+        if tmpl_field.type == "single_select" and not tmpl_field.allow_unknown_values:
+            strict_field_options[tmpl_field.id] = {opt.value for opt in rf.options}
+
+    unknown_value_errors: list[str] = []
+    for r_issue in resolved_issues:
+        for field_key, value in r_issue.fields.items():
+            allowed = strict_field_options.get(field_key)
+            if allowed is not None and value not in allowed:
+                unknown_value_errors.append(
+                    f"Issue {r_issue.template_id}: field '{field_key}' value "
+                    f"'{value}' is not a declared option. Add the value to the "
+                    f"field's options, or set allow_unknown_values: true on the field."
+                )
+    if unknown_value_errors:
+        raise ValueError("Field value validation failed:\n  " + "\n  ".join(unknown_value_errors))
+
     # ── Step 8: Resolve project description ({DATE}) ──────────────
     project_desc = instance.project.description.replace("{DATE}", date.today().isoformat())
 

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -11,7 +11,7 @@ from plynth.models.plan import (
     ResolvedIssue,
     ResolvedMilestone,
 )
-from plynth.models.template import KNOWN_OPTION_COLORS, TemplateDefinition
+from plynth.models.template import TemplateDefinition
 
 # Matches {PREFIX}-### patterns in issue bodies (cross-references).
 _CROSSREF_RE = re.compile(r"\{PREFIX\}-(\d{3})")
@@ -157,29 +157,20 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
         )
 
     # ── Step 6: Resolve field options ──────────────────────────────
-    # Pre-flight option colors against the GHES floor. Out-of-set colors get
-    # downgraded to GRAY with a warning so the run completes against any
-    # supported version. Templates authored against newer GHES that adds
-    # colors will degrade gracefully on the 3.19 floor.
+    # Color is validated against OptionColor at template parse time, so any
+    # color reaching here is already legal. None means "operator left it off"
+    # which we materialize as GRAY for the GraphQL mutation.
     resolved_field_defs: list[ResolvedField] = []
     for f in template.fields:
-        opts: list[ResolvedFieldOption] = []
-        for opt in f.options:
-            color = opt.color
-            if color is not None and color not in KNOWN_OPTION_COLORS:
-                warnings.append(
-                    f"Field '{f.id}' option '{opt.value}': color '{color}' not in "
-                    f"the supported set {sorted(KNOWN_OPTION_COLORS)}; using GRAY"
-                )
-                color = "GRAY"
-            opts.append(
-                ResolvedFieldOption(
-                    value=resolve_placeholders(opt.value, values),
-                    color=color or "GRAY",
-                    description=resolve_placeholders(opt.description, values),
-                    default=opt.default,
-                )
+        opts = [
+            ResolvedFieldOption(
+                value=resolve_placeholders(opt.value, values),
+                color=opt.color or "GRAY",
+                description=resolve_placeholders(opt.description, values),
+                default=opt.default,
             )
+            for opt in f.options
+        ]
         resolved_field_defs.append(ResolvedField(id=f.id, name=f.name, type=f.type, options=opts))
 
     # ── Step 7: Enforce allow_unknown_values guard ─────────────────

--- a/plynth/models/plan.py
+++ b/plynth/models/plan.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
-from plynth.models.template import StatusOption, ViewDefinition
+from plynth.models.template import OptionColor, StatusOption, ViewDefinition
 
 
 class ResolvedIssue(BaseModel):
@@ -32,6 +32,17 @@ class ResolvedMilestone(BaseModel):
     due_date: str | None = None
 
 
+class ResolvedFieldOption(BaseModel):
+    """A single-select option after placeholder resolution and color pre-flight."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: str
+    color: OptionColor = "GRAY"
+    description: str = ""
+    default: bool = False
+
+
 class ResolvedField(BaseModel):
     """A field with placeholder-resolved options."""
 
@@ -40,7 +51,7 @@ class ResolvedField(BaseModel):
     id: str
     name: str
     type: str
-    options: list[str]
+    options: list[ResolvedFieldOption]
 
 
 class ExecutionPlan(BaseModel):

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -5,10 +5,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # GitHub's Projects V2 single-select option color set. Sourced from the GHES
-# 3.19 GraphQL schema (ProjectV2SingleSelectFieldOptionColor enum). Anything
-# outside this set is downgraded to GRAY at plan time with a warning so the
-# run still completes against the GHES floor.
-KNOWN_OPTION_COLORS = ("GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN", "ORANGE", "PINK")
+# 3.19 GraphQL schema (ProjectV2SingleSelectFieldOptionColor enum). Pydantic
+# rejects out-of-set colors at template parse time, so the engine never sees
+# an invalid value. Add an entry here when a future GHES version adds one.
 OptionColor = Literal["GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN", "ORANGE", "PINK"]
 
 

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -189,8 +189,8 @@ class TemplateDefinition(BaseModel):
     issues: list[IssueDefinition] = []
     views: list[ViewDefinition] = []
     pruning: PruningConfig | None = None
-    defaults: TemplateDefaults = TemplateDefaults()
-    reconciliation: ReconciliationConfig = ReconciliationConfig()
+    defaults: TemplateDefaults = Field(default_factory=TemplateDefaults)
+    reconciliation: ReconciliationConfig = Field(default_factory=ReconciliationConfig)
 
     @model_validator(mode="after")
     def _validate_references(self) -> TemplateDefinition:

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# GitHub's Projects V2 single-select option color set. Sourced from the GHES
+# 3.19 GraphQL schema (ProjectV2SingleSelectFieldOptionColor enum). Anything
+# outside this set is downgraded to GRAY at plan time with a warning so the
+# run still completes against the GHES floor.
+KNOWN_OPTION_COLORS = ("GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN", "ORANGE", "PINK")
+OptionColor = Literal["GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN", "ORANGE", "PINK"]
 
 
 class TemplateMetadata(BaseModel):
@@ -29,13 +36,51 @@ class StatusOption(BaseModel):
     color: Literal["GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN"]
 
 
+class FieldOption(BaseModel):
+    """Rich form of a single-select field option.
+
+    Templates may declare options as plain strings (legacy) or as objects
+    with color/description/default/aliases/deprecated. A field_validator on
+    FieldDefinition.options normalizes strings to FieldOption(value=...) so
+    the engine sees one shape post-parse.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: Annotated[str, Field(max_length=100)]
+    color: OptionColor | None = None
+    description: str = Field(default="", max_length=2_000)
+    default: bool = False
+    aliases: list[Annotated[str, Field(max_length=100)]] = []
+    deprecated: bool = False
+
+
 class FieldDefinition(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str
     name: str
     type: Literal["single_select", "text", "number", "date", "iteration"]
-    options: list[Annotated[str, Field(max_length=100)]] = []
+    options: list[FieldOption] = []
+    allow_unknown_values: bool = False
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def _normalize_options(cls, v: Any) -> Any:
+        """Accept legacy string options or rich objects. Strings become FieldOption(value=...)."""
+        if not isinstance(v, list):
+            return v
+        return [{"value": opt} if isinstance(opt, str) else opt for opt in v]
+
+    @model_validator(mode="after")
+    def _at_most_one_default(self) -> FieldDefinition:
+        defaults = [opt.value for opt in self.options if opt.default]
+        if len(defaults) > 1:
+            raise ValueError(
+                f"Field '{self.id}': at most one option may have default: true "
+                f"(found {len(defaults)}: {defaults})"
+            )
+        return self
 
 
 class MilestoneDefinition(BaseModel):
@@ -104,6 +149,34 @@ class PruningConfig(BaseModel):
     rules: list[PruningRule]
 
 
+class TemplateDefaults(BaseModel):
+    """Template-level defaults applied to every issue unless overridden.
+
+    Precedence (lowest to highest): engine fallback, template defaults,
+    per-issue values, instance field_overrides. Labels are intentionally
+    deferred until the labels-and-issue-types feature lands.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    fields: dict[str, str] = {}
+
+
+class ReconciliationConfig(BaseModel):
+    """Reserved namespace for the reconciliation/verify lifecycle.
+
+    Today only ``mode: none`` is honored. ``report_only`` parses but is
+    treated identically to ``none`` until the verify subcommand lands.
+    The namespace is reserved now because every model uses extra="forbid",
+    so adding fields later breaks anyone who put a placeholder block in.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["none", "report_only"] = "none"
+    verify_after_apply: bool = False
+
+
 class TemplateDefinition(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -116,6 +189,8 @@ class TemplateDefinition(BaseModel):
     issues: list[IssueDefinition] = []
     views: list[ViewDefinition] = []
     pruning: PruningConfig | None = None
+    defaults: TemplateDefaults = TemplateDefaults()
+    reconciliation: ReconciliationConfig = ReconciliationConfig()
 
     @model_validator(mode="after")
     def _validate_references(self) -> TemplateDefinition:
@@ -162,6 +237,10 @@ class TemplateDefinition(BaseModel):
                 for ref in rule.remove_issues:
                     if ref not in template_ids:
                         errors.append(f"Pruning remove_issues ref '{ref}' not found in issues")
+
+        for field_key in self.defaults.fields:
+            if field_key not in field_ids:
+                errors.append(f"defaults.fields: key '{field_key}' not found in fields")
 
         if errors:
             raise ValueError("Template reference validation failed:\n  " + "\n  ".join(errors))

--- a/tests/test_models_template.py
+++ b/tests/test_models_template.py
@@ -112,3 +112,109 @@ def test_field_option_name_over_limit_rejected() -> None:
     data["fields"][0]["options"] = ["x" * 101]
     with pytest.raises(ValidationError):
         TemplateDefinition.model_validate(data)
+
+
+# ── M1-A: rich field option objects ────────────────────────────────
+
+
+def test_field_option_legacy_string_form_normalizes() -> None:
+    data = _base_template_dict()
+    data["fields"][0]["options"] = ["P1", "P2"]
+    t = TemplateDefinition.model_validate(data)
+    opts = t.fields[0].options
+    assert [o.value for o in opts] == ["P1", "P2"]
+    assert all(o.color is None for o in opts)
+    assert all(o.description == "" for o in opts)
+    assert all(o.default is False for o in opts)
+
+
+def test_field_option_rich_form_roundtrips() -> None:
+    data = _base_template_dict()
+    data["fields"][0]["options"] = [
+        "P1",
+        {
+            "value": "P2",
+            "color": "RED",
+            "description": "Critical",
+            "default": True,
+            "aliases": ["urgent"],
+            "deprecated": False,
+        },
+    ]
+    t = TemplateDefinition.model_validate(data)
+    opts = t.fields[0].options
+    assert opts[0].value == "P1" and opts[0].color is None
+    assert opts[1].value == "P2"
+    assert opts[1].color == "RED"
+    assert opts[1].description == "Critical"
+    assert opts[1].default is True
+    assert opts[1].aliases == ["urgent"]
+
+
+def test_field_option_invalid_color_rejected() -> None:
+    data = _base_template_dict()
+    data["fields"][0]["options"] = [{"value": "P1", "color": "TEAL"}]
+    with pytest.raises(ValidationError):
+        TemplateDefinition.model_validate(data)
+
+
+def test_field_option_two_defaults_rejected() -> None:
+    data = _base_template_dict()
+    data["fields"][0]["options"] = [
+        {"value": "P1", "default": True},
+        {"value": "P2", "default": True},
+    ]
+    with pytest.raises(ValidationError, match="at most one option may have default"):
+        TemplateDefinition.model_validate(data)
+
+
+def test_field_allow_unknown_values_defaults_false() -> None:
+    data = _base_template_dict()
+    t = TemplateDefinition.model_validate(data)
+    assert t.fields[0].allow_unknown_values is False
+
+
+# ── M1-B: template-level defaults ──────────────────────────────────
+
+
+def test_template_defaults_default_empty() -> None:
+    t = TemplateDefinition.model_validate(_base_template_dict())
+    assert t.defaults.fields == {}
+
+
+def test_template_defaults_parses() -> None:
+    data = _base_template_dict()
+    data["defaults"] = {"fields": {"priority": "P1"}}
+    t = TemplateDefinition.model_validate(data)
+    assert t.defaults.fields == {"priority": "P1"}
+
+
+def test_template_defaults_unknown_field_key_rejected() -> None:
+    data = _base_template_dict()
+    data["defaults"] = {"fields": {"nope": "x"}}
+    with pytest.raises(ValidationError, match="defaults.fields: key 'nope' not found"):
+        TemplateDefinition.model_validate(data)
+
+
+# ── M1-G: reconciliation namespace stub ────────────────────────────
+
+
+def test_reconciliation_default_none() -> None:
+    t = TemplateDefinition.model_validate(_base_template_dict())
+    assert t.reconciliation.mode == "none"
+    assert t.reconciliation.verify_after_apply is False
+
+
+def test_reconciliation_report_only_parses() -> None:
+    data = _base_template_dict()
+    data["reconciliation"] = {"mode": "report_only", "verify_after_apply": True}
+    t = TemplateDefinition.model_validate(data)
+    assert t.reconciliation.mode == "report_only"
+    assert t.reconciliation.verify_after_apply is True
+
+
+def test_reconciliation_invalid_mode_rejected() -> None:
+    data = _base_template_dict()
+    data["reconciliation"] = {"mode": "apply"}
+    with pytest.raises(ValidationError):
+        TemplateDefinition.model_validate(data)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -124,7 +124,7 @@ def test_format_dry_run_shape(
     assert "Fields" in output
 
 
-# ── M1-A: rich field option resolution + color pre-flight ────────
+# ── M1-A: rich field option resolution ────────────────────────────
 
 
 def test_plan_rich_field_options_carry_color_and_description(
@@ -139,19 +139,6 @@ def test_plan_rich_field_options_carry_color_and_description(
     assert first.description == "Critical"
 
 
-def test_plan_unknown_color_downgraded_to_gray_with_warning(
-    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
-) -> None:
-    # Bypass the schema validator (which would block this) by writing the
-    # color directly. The planner is the second line of defense for templates
-    # authored against newer GHES that adds colors.
-    minimal_template.fields[0].options[0].color = "TEAL"  # type: ignore[assignment]
-    ep = plan(minimal_template, minimal_instance)
-    priority = next(f for f in ep.fields if f.id == "priority")
-    assert priority.options[0].color == "GRAY"
-    assert any("color 'TEAL' not in the supported set" in w for w in ep.warnings)
-
-
 def test_plan_known_color_unchanged(
     minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
 ) -> None:
@@ -159,7 +146,17 @@ def test_plan_known_color_unchanged(
     ep = plan(minimal_template, minimal_instance)
     priority = next(f for f in ep.fields if f.id == "priority")
     assert priority.options[0].color == "PURPLE"
-    assert not any("not in the supported set" in w for w in ep.warnings)
+
+
+def test_plan_omitted_color_materializes_as_gray(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    # Templates can leave color unset (None). The engine materializes None
+    # as GRAY for the GraphQL mutation, which expects a concrete color.
+    assert minimal_template.fields[0].options[0].color is None
+    ep = plan(minimal_template, minimal_instance)
+    priority = next(f for f in ep.fields if f.id == "priority")
+    assert priority.options[0].color == "GRAY"
 
 
 # ── M1-B: template defaults precedence ────────────────────────────

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -52,8 +52,9 @@ def test_plan_resolves_team_placeholder_in_field_options(
 ) -> None:
     ep = plan(minimal_template, minimal_instance)
     priority = next(f for f in ep.fields if f.id == "priority")
-    assert "Platform" in priority.options
-    assert "{TEAM}" not in priority.options
+    values = [opt.value for opt in priority.options]
+    assert "Platform" in values
+    assert all("{TEAM}" not in v for v in values)
 
 
 def test_plan_preserves_crossrefs_in_bodies(
@@ -121,3 +122,77 @@ def test_format_dry_run_shape(
     assert "Milestones" in output
     assert "Issues" in output
     assert "Fields" in output
+
+
+# ── M1-A: rich field option resolution + color pre-flight ────────
+
+
+def test_plan_rich_field_options_carry_color_and_description(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.fields[0].options[0].color = "RED"
+    minimal_template.fields[0].options[0].description = "Critical"
+    ep = plan(minimal_template, minimal_instance)
+    priority = next(f for f in ep.fields if f.id == "priority")
+    first = priority.options[0]
+    assert first.color == "RED"
+    assert first.description == "Critical"
+
+
+def test_plan_unknown_color_downgraded_to_gray_with_warning(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    # Bypass the schema validator (which would block this) by writing the
+    # color directly. The planner is the second line of defense for templates
+    # authored against newer GHES that adds colors.
+    minimal_template.fields[0].options[0].color = "TEAL"  # type: ignore[assignment]
+    ep = plan(minimal_template, minimal_instance)
+    priority = next(f for f in ep.fields if f.id == "priority")
+    assert priority.options[0].color == "GRAY"
+    assert any("color 'TEAL' not in the supported set" in w for w in ep.warnings)
+
+
+def test_plan_known_color_unchanged(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.fields[0].options[0].color = "PURPLE"
+    ep = plan(minimal_template, minimal_instance)
+    priority = next(f for f in ep.fields if f.id == "priority")
+    assert priority.options[0].color == "PURPLE"
+    assert not any("not in the supported set" in w for w in ep.warnings)
+
+
+# ── M1-B: template defaults precedence ────────────────────────────
+
+
+def test_plan_template_defaults_applied_when_issue_omits(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.defaults.fields = {"priority": "P2"}
+    # Strip the per-issue priority on the first issue so the default kicks in.
+    minimal_template.issues[0].fields = {}
+    ep = plan(minimal_template, minimal_instance)
+    first = next(i for i in ep.issues if i.template_id == minimal_template.issues[0].template_id)
+    assert first.fields.get("priority") == "P2"
+
+
+def test_plan_per_issue_field_wins_over_template_default(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.defaults.fields = {"priority": "P2"}
+    minimal_template.issues[0].fields = {"priority": "P1"}
+    ep = plan(minimal_template, minimal_instance)
+    first = next(i for i in ep.issues if i.template_id == minimal_template.issues[0].template_id)
+    assert first.fields.get("priority") == "P1"
+
+
+def test_plan_instance_override_wins_over_per_issue_and_defaults(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.defaults.fields = {"priority": "P2"}
+    minimal_template.issues[0].fields = {"priority": "P1"}
+    tid = minimal_template.issues[0].template_id
+    minimal_instance.field_overrides = {tid: {"priority": "Platform"}}
+    ep = plan(minimal_template, minimal_instance)
+    first = next(i for i in ep.issues if i.template_id == tid)
+    assert first.fields.get("priority") == "Platform"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -196,3 +196,45 @@ def test_plan_instance_override_wins_over_per_issue_and_defaults(
     ep = plan(minimal_template, minimal_instance)
     first = next(i for i in ep.issues if i.template_id == tid)
     assert first.fields.get("priority") == "Platform"
+
+
+# ── M1-A: allow_unknown_values guard at plan time ──────────────────
+
+
+def test_plan_unknown_field_value_rejected_by_default(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    # priority field defaults to allow_unknown_values=False; "Bogus" isn't
+    # in the declared option set, so plan-time validation should fail.
+    minimal_template.issues[0].fields = {"priority": "Bogus"}
+    with pytest.raises(ValueError, match="not a declared option"):
+        plan(minimal_template, minimal_instance)
+
+
+def test_plan_unknown_field_value_allowed_when_allow_unknown_values_true(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    priority = next(f for f in minimal_template.fields if f.id == "priority")
+    priority.allow_unknown_values = True
+    minimal_template.issues[0].fields = {"priority": "Bogus"}
+    ep = plan(minimal_template, minimal_instance)
+    first = next(i for i in ep.issues if i.template_id == minimal_template.issues[0].template_id)
+    assert first.fields["priority"] == "Bogus"
+
+
+def test_plan_unknown_value_via_template_default_rejected(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.defaults.fields = {"priority": "Nope"}
+    minimal_template.issues[0].fields = {}
+    with pytest.raises(ValueError, match="not a declared option"):
+        plan(minimal_template, minimal_instance)
+
+
+def test_plan_unknown_value_via_instance_override_rejected(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    tid = minimal_template.issues[0].template_id
+    minimal_instance.field_overrides = {tid: {"priority": "BadOverride"}}
+    with pytest.raises(ValueError, match="not a declared option"):
+        plan(minimal_template, minimal_instance)


### PR DESCRIPTION
Lands the three M1 schema-additive issues together because they all extend `TemplateDefinition` and share a single planner-resolution change. Existing templates parse and execute identically.

Closes #42, #43, #44.

## What's in

- **Rich field option objects** (#42). `FieldOption(value, color, description, default, aliases, deprecated)`. Plain string options still work; a `field_validator` normalizes them to `FieldOption(value=...)` so the engine sees one shape post-parse. Mixed forms allowed in the same field. New field-level `allow_unknown_values: bool = False`. At-most-one-default model_validator. `KNOWN_OPTION_COLORS` pre-flight in the planner downgrades out-of-set colors to `GRAY` with a structured warning so the run completes against the GHES floor. Phase 1 (`engine/phases.py`) now passes `color`/`description` to `singleSelectOptions`. Critical comment above `create_field` in `engine/graphql_client.py` documents that ProjectV2 option mutations replace the full list — future reconciliation work must read-modify-write or option-id-bearing field values get destroyed.
- **Template-level defaults** (#43). New `defaults.fields` on `TemplateDefinition`. Planner precedence: template defaults < per-issue values < instance `field_overrides`. Reference validator rejects unknown field keys in `defaults.fields`. Labels deferred to the M2 labels-and-issue-types feature.
- **`reconciliation:` namespace stub** (#44). New `reconciliation` block: `mode` (`none`|`report_only`) and `verify_after_apply`. Only `mode: none` is honored today. Reserving the namespace now because `extra="forbid"` is set on every model, so adding the block later breaks anyone who put a placeholder in.

## Out of scope (intentional)

- Per-issue `labels` and `issue_type` (M2 / #...). `defaults.labels` waits for that work.
- Instance-level `label_overrides`/`issue_overrides` (M4).
- The `verify` subcommand and live reconciliation (M5 + companion repo).
- `schema_version` cadence and load-path compat shims (M1-S / #45).

## Tests

`pytest -q` — 151 passed, 2 skipped (Windows-only POSIX skips). New tests:

- `test_models_template.py`: legacy string form normalizes; rich form roundtrips; invalid color rejected; two defaults rejected; `allow_unknown_values` defaults false; `defaults.fields` parses + unknown-key rejection; `reconciliation` defaults to `mode=none`, `report_only` parses, invalid mode rejected.
- `test_planner.py`: rich options carry color/description through to `ResolvedFieldOption`; unknown color downgrades to GRAY and emits a warning; known color unchanged; defaults applied when issue omits; per-issue wins over default; instance override wins over both.

`ruff check`, `ruff format --check`, `mypy plynth` all green.

## Docs

- New `docs/options.md` covering both option forms with the categorical-color appendix (Doc-3 / #48 lands its tweaks on top of this).
- `docs/example-template.yaml` and `docs/plynth-design-spec.md` updated to demonstrate the rich form and the new sections.
- CHANGELOG bullets under `[Unreleased]`.

Stacks logically on #49 (the `.gitignore` change) but doesn't depend on it.
