### PR TITLE
feat(engine): create repo when repo.create is true (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   model uses `extra="forbid"`, so adding fields later breaks anyone who
   already put a placeholder block in. `verify_after_apply` will be wired
   to the verify subcommand when it ships.
+- **Repo creation when `repo.create: true`** (#13). With `repo.create: true`
+  in the instance config, Phase 1 creates the target repository (private)
+  via REST before resolving its node ID, instead of failing with
+  `NotFoundError`. Existing repos are a no-op; `repo.create: false`
+  (default) keeps the old friendly error. Repo creation needs more than
+  the standard plynth permissions: classic `repo` already covers it; a
+  fine-grained PAT also needs organization *Administration: Read and write*.
+  See SECURITY.md.
 
 ### Changed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,9 +41,15 @@ Configure with:
     organization level, so this permission lives in the *Organization*
     section, not under the repository.
 
-No other permissions are required. Granting `Contents`, `Pull requests`,
-or org-wide repo access broadens the blast radius of a leaked token
-without enabling any plynth feature.
+No other permissions are required for the standard bootstrap flow.
+Granting `Contents`, `Pull requests`, or org-wide repo access broadens
+the blast radius of a leaked token without enabling any plynth feature.
+
+If your instance config sets `repo.create: true`, plynth additionally
+needs to call `POST /orgs/{org}/repos` before Phase 1. Add organization
+*Administration: Read and write* to the fine-grained PAT for that case.
+A classic PAT with `repo` scope already covers it. Drop the permission
+once the repo exists; subsequent runs against the same repo do not need it.
 
 > **GHES 3.19 caveat.** GHES 3.19 exposes the ProjectV2 GraphQL
 > mutations, but the required fine-grained PAT permission for

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -10,7 +10,7 @@ import yaml
 
 from plynth.engine.graphql_client import GraphQLClient
 from plynth.engine.rest_client import RESTClient
-from plynth.errors import PlynthError
+from plynth.errors import NotFoundError, PlynthError
 from plynth.models.plan import ExecutionPlan, ResolvedIssue
 from plynth.models.state import (
     PHASE_1_PROJECT_AND_FIELDS,
@@ -111,7 +111,7 @@ class PhaseOrchestrator:
 
         # 1a. Resolve org and repo IDs
         org_id = self.gql.get_org_id(self.plan.instance_org)
-        repo_id = self.gql.get_repo_id(self.plan.instance_org, self.plan.instance_repo)
+        repo_id = self._resolve_repo_id()
         self.state.repo = RepoState(name=self.plan.instance_repo, node_id=repo_id)
 
         # 1b. Create the project
@@ -163,6 +163,24 @@ class PhaseOrchestrator:
                     options_map[opt["name"]] = opt["id"]
 
             self.state.fields[field_def.id] = FieldState(node_id=raw["id"], options=options_map)
+
+    def _resolve_repo_id(self) -> str:
+        """Look up the repo node ID, creating the repo first if configured.
+
+        With `repo.create: false` (default), a missing repo raises NotFoundError
+        as before. With `repo.create: true`, plynth creates the repo (private)
+        via REST and re-resolves. An already-existing repo is a no-op either way.
+        """
+        org = self.plan.instance_org
+        name = self.plan.instance_repo
+        try:
+            return self.gql.get_repo_id(org, name)
+        except NotFoundError:
+            if not self.plan.instance_repo_create:
+                raise
+            self.log.info(f"Repository {org}/{name} not found, creating (repo.create=true)")
+            self.rest.create_repo(org, name)
+            return self.gql.get_repo_id(org, name)
 
     # ── Phase 2: Create Milestones ─────────────────────────
 

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -205,6 +205,7 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
         template_version=template.template.version,
         instance_org=instance.org,
         instance_repo=instance.repo.name,
+        instance_repo_create=instance.repo.create,
         target=instance.target,
         project_name=instance.project.name,
         project_description=project_desc,

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -70,3 +70,55 @@ class RESTClient:
         raise NetworkError(
             f"Max retries ({self.base.max_retries}) exceeded creating milestone '{title}'"
         )
+
+    def create_repo(self, org: str, name: str) -> dict:
+        """Create a private repository in `org`.
+
+        Used by Phase 1 when `repo.create: true` and the target repo does not
+        yet exist. Created private by design: plynth bootstraps internal
+        project tracking, and a public default would be a surprise.
+
+        Requires permissions beyond the standard plynth set: classic `repo`
+        scope already covers it, but a fine-grained PAT also needs the
+        organization `Administration: Read and write` permission. See
+        SECURITY.md.
+
+        Returns: {"node_id": "R_...", "name": "..."}
+        """
+        self.base._wait_for_write_delay()
+
+        url = f"{self.base.rest_base}/orgs/{org}/repos"
+        payload = {"name": name, "private": True}
+
+        for attempt in range(self.base.max_retries):
+            try:
+                response = self.base.session.post(
+                    url, json=payload, timeout=self.base.request_timeout_s
+                )
+            except requests.Timeout as e:
+                raise NetworkError(
+                    f"REST request to {url} timed out after {self.base.request_timeout_s}s"
+                ) from e
+            except requests.ConnectionError as e:
+                raise NetworkError(f"Could not connect to {self.base.display_target}: {e}") from e
+
+            if response.ok:
+                self.base._record_write()
+                data = response.json()
+                return {"node_id": data["node_id"], "name": data["name"]}
+
+            if response.status_code == 401:
+                raise AuthError(
+                    f"Token rejected by {self.base.display_target}; creating a repo "
+                    f"requires `repo` (classic) or organization Administration: write "
+                    f"(fine-grained)."
+                )
+            if response.status_code == 404:
+                raise NotFoundError(f"Organization {org} not found on {self.base.display_target}")
+
+            if not self.base._handle_retry(response, attempt):
+                response.raise_for_status()
+
+        raise NetworkError(
+            f"Max retries ({self.base.max_retries}) exceeded creating repo '{org}/{name}'"
+        )

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -110,7 +110,7 @@ class RESTClient:
             if response.status_code == 401:
                 raise AuthError(
                     f"Token rejected by {self.base.display_target}; creating a repo "
-                    f"requires `repo` (classic) or organization Administration: write "
+                    f"requires `repo` (classic) or organization Administration: Read and write "
                     f"(fine-grained)."
                 )
             if response.status_code == 404:

--- a/plynth/models/plan.py
+++ b/plynth/models/plan.py
@@ -64,6 +64,7 @@ class ExecutionPlan(BaseModel):
     template_version: str
     instance_org: str
     instance_repo: str
+    instance_repo_create: bool = False
     target: str
     project_name: str
     project_description: str

--- a/tests/test_phases_repo_create.py
+++ b/tests/test_phases_repo_create.py
@@ -1,0 +1,80 @@
+"""Tests for Phase 1's `repo.create: true` path (issue #13).
+
+Covers the three acceptance cases:
+- create=true + missing repo → create, then proceed
+- create=true + existing repo → no-op (idempotent), proceed
+- create=false (default) + missing repo → friendly NotFoundError, no create call
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from plynth.engine.phases import PhaseOrchestrator
+from plynth.errors import NotFoundError
+from plynth.models.state import StateFile
+
+
+def _make_orchestrator(
+    mocker: MockerFixture,
+    state_path: Path,
+    *,
+    repo_create: bool,
+) -> PhaseOrchestrator:
+    plan = mocker.MagicMock()
+    plan.instance_org = "example-org"
+    plan.instance_repo = "acme"
+    plan.instance_repo_create = repo_create
+    state = StateFile(target="https://ghes.example.com", org="example-org")
+    return PhaseOrchestrator(
+        plan=plan,
+        gql=mocker.MagicMock(),
+        rest=mocker.MagicMock(),
+        state=state,
+        state_path=state_path,
+        logger=logging.getLogger("plynth.test"),
+    )
+
+
+def test_repo_create_true_missing_repo_creates_then_resolves(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    orch = _make_orchestrator(mocker, tmp_path / "state.yaml", repo_create=True)
+    # First lookup misses, second lookup (post-create) hits.
+    orch.gql.get_repo_id.side_effect = [
+        NotFoundError("Could not resolve to a Repository"),
+        "R_after_create",
+    ]
+
+    repo_id = orch._resolve_repo_id()
+
+    assert repo_id == "R_after_create"
+    orch.rest.create_repo.assert_called_once_with("example-org", "acme")
+    assert orch.gql.get_repo_id.call_count == 2
+
+
+def test_repo_create_true_existing_repo_is_noop(mocker: MockerFixture, tmp_path: Path) -> None:
+    orch = _make_orchestrator(mocker, tmp_path / "state.yaml", repo_create=True)
+    orch.gql.get_repo_id.return_value = "R_existing"
+
+    repo_id = orch._resolve_repo_id()
+
+    assert repo_id == "R_existing"
+    orch.rest.create_repo.assert_not_called()
+    assert orch.gql.get_repo_id.call_count == 1
+
+
+def test_repo_create_false_missing_repo_propagates_not_found(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    orch = _make_orchestrator(mocker, tmp_path / "state.yaml", repo_create=False)
+    orch.gql.get_repo_id.side_effect = NotFoundError("Could not resolve to a Repository")
+
+    with pytest.raises(NotFoundError, match="Could not resolve to a Repository"):
+        orch._resolve_repo_id()
+
+    orch.rest.create_repo.assert_not_called()

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -8,9 +8,11 @@ import responses
 
 from plynth.engine.api_base import GitHubClient
 from plynth.engine.rest_client import RESTClient
+from plynth.errors import AuthError, NotFoundError
 
 GHES_URL = "https://ghes.example.com"
 MILESTONE_URL = f"{GHES_URL}/api/v3/repos/example-org/acme/milestones"
+ORG_REPOS_URL = f"{GHES_URL}/api/v3/orgs/example-org/repos"
 
 
 def _client() -> RESTClient:
@@ -63,3 +65,57 @@ def test_create_milestone_422_raises() -> None:
     )
     with pytest.raises(requests.HTTPError):
         _client().create_milestone(owner="example-org", repo="acme", title="T")
+
+
+@responses.activate
+def test_create_repo_happy_path() -> None:
+    responses.add(
+        responses.POST,
+        ORG_REPOS_URL,
+        json={"node_id": "R_kgDO123", "name": "acme"},
+        status=201,
+    )
+    result = _client().create_repo(org="example-org", name="acme")
+    assert result == {"node_id": "R_kgDO123", "name": "acme"}
+
+    sent_body = json.loads(responses.calls[0].request.body)
+    assert sent_body == {"name": "acme", "private": True}
+
+
+@responses.activate
+def test_create_repo_401_raises_auth_error() -> None:
+    responses.add(
+        responses.POST,
+        ORG_REPOS_URL,
+        json={"message": "Bad credentials"},
+        status=401,
+    )
+    with pytest.raises(AuthError, match="creating a repo requires"):
+        _client().create_repo(org="example-org", name="acme")
+
+
+@responses.activate
+def test_create_repo_404_raises_not_found() -> None:
+    responses.add(
+        responses.POST,
+        ORG_REPOS_URL,
+        json={"message": "Not Found"},
+        status=404,
+    )
+    with pytest.raises(NotFoundError, match="Organization example-org not found"):
+        _client().create_repo(org="example-org", name="acme")
+
+
+@responses.activate
+def test_create_repo_422_raises() -> None:
+    """Name collision (repo already exists) surfaces as HTTPError. The Phase 1
+    flow avoids this case by checking existence with get_repo_id first; this
+    test pins the contract for any direct caller."""
+    responses.add(
+        responses.POST,
+        ORG_REPOS_URL,
+        json={"message": "name already exists on this account"},
+        status=422,
+    )
+    with pytest.raises(requests.HTTPError):
+        _client().create_repo(org="example-org", name="acme")


### PR DESCRIPTION
Closes #13.

## What changed

Phase 1 used to fail with `NotFoundError` if the target repo did not exist, even though `RepoConfig.create` was already accepted in the instance schema. Now Phase 1 looks up the repo, and on `NotFoundError` + `instance_repo_create` it creates the repo (private) via REST and re-resolves.

- `repo.create: true` + missing repo -> creates, then proceeds.
- `repo.create: true` + existing repo -> no-op (idempotent), proceeds.
- `repo.create: false` (default) + missing repo -> unchanged friendly `NotFoundError`.

## Implementation notes

- New `RESTClient.create_repo(org, name)` -> `POST /orgs/{org}/repos` with `{name, private: true}`. Defaulted private because plynth bootstraps internal project tracking and a public default would be a surprise. Happy to flip if that's wrong for your use case.
- `ExecutionPlan` grows `instance_repo_create`, populated from `instance.repo.create` at plan time.
- New `_resolve_repo_id()` helper on the orchestrator keeps Phase 1 linear and isolates the create-on-missing branch.

## Permissions caveat

Repo creation needs more than the standard plynth permission set:
- Classic PAT: `repo` already covers it.
- Fine-grained PAT: also needs organization **Administration: Read and write**.

Documented in SECURITY.md (alongside the standard set) and called out in the CHANGELOG entry. Permission can be dropped after first run.

## Tests

- `tests/test_rest_client.py` adds HTTP-mocked happy/401/404/422 paths on `create_repo`.
- `tests/test_phases_repo_create.py` covers the three acceptance cases against mocked clients.
- Full suite: 162 passed, 2 skipped (pre-existing POSIX-only skips).