### PR TITLE
feat(engine): GHES version detection via /api/v3/meta (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   model uses `extra="forbid"`, so adding fields later breaks anyone who
   already put a placeholder block in. `verify_after_apply` will be wired
   to the verify subcommand when it ships.
+- **GHES version detection** (#15). On startup, plynth now probes
+  `GET {target}/api/v3/meta` for GHES targets and caches the parsed
+  `installed_version` as a `(major, minor)` tuple on the base client. Used
+  by `GitHubClient.warn_if_below(min_version, feature, log)` to emit a
+  friendly warning when a feature requires a higher minor version than
+  the detected one. github.com targets skip the probe (no version field
+  in `/meta` and no useful gating). Detection failures (404, network
+  error, malformed response) log a warning and leave the version as
+  `None`; nothing fails. Prepares the ground for view-API gating
+  (GHES 3.20+) once view automation lands.
 - **Repo creation when `repo.create: true`** (#13). With `repo.create: true`
   in the instance config, Phase 1 creates the target repository (private)
   via REST before resolving its node ID, instead of failing with

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -166,6 +166,9 @@ def _cmd_create(args: argparse.Namespace, log: logging.Logger) -> None:
     gql = GraphQLClient(base)
     rest = RESTClient(base)
 
+    # 5b. Detect GHES version (no-op for github.com; informational on failure).
+    rest.detect_installed_version(log)
+
     # 6. Initialize or resume state file
     state_dir = _resolve_state_dir(args.state_dir)
     state_path = state_dir / f"{_slugify(execution_plan.project_name)}.plynth-state.yaml"
@@ -195,6 +198,7 @@ def _cmd_resolve(args: argparse.Namespace, log: logging.Logger) -> None:
     base = GitHubClient(instance.target, token, request_timeout_s=args.timeout_seconds)
     gql = GraphQLClient(base)
     rest = RESTClient(base)
+    rest.detect_installed_version(log)
 
     # Load existing state
     state = _load_state(Path(args.state))

--- a/plynth/engine/api_base.py
+++ b/plynth/engine/api_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 import warnings
 from importlib import metadata
@@ -82,11 +83,41 @@ class GitHubClient:
         self.max_retries = max_retries
         self.request_timeout_s = request_timeout_s
         self._last_write_time: float = 0.0
+        # Populated by RESTClient.detect_installed_version() for GHES targets.
+        # Stays None on github.com (no /meta version) and on detection failure.
+        self.installed_version: tuple[int, int] | None = None
 
     @property
     def display_target(self) -> str:
         """Human-readable target for diagnostics. Empty string → 'github.com'."""
         return self.target if self.target else "github.com"
+
+    @property
+    def is_ghes(self) -> bool:
+        """True if the target is a GHES instance (not github.com / api.github.com)."""
+        return self.target not in ("", "github.com", "https://api.github.com")
+
+    def warn_if_below(
+        self,
+        min_version: tuple[int, int],
+        feature: str,
+        log: logging.Logger,
+    ) -> None:
+        """Log a warning if the GHES version is known and below `min_version`.
+
+        github.com (where `installed_version` is None) is treated as latest and
+        never warns. A failed detection (also None) is silent because the
+        detection itself logged the failure; warning here would double up.
+        """
+        if self.installed_version is None:
+            return
+        if self.installed_version < min_version:
+            have = f"{self.installed_version[0]}.{self.installed_version[1]}"
+            need = f"{min_version[0]}.{min_version[1]}"
+            log.warning(
+                f"Feature '{feature}' requires GHES {need}+, detected {have}. "
+                f"Continuing; the feature may be skipped or fail at the API."
+            )
 
     def _wait_for_write_delay(self) -> None:
         """Enforce minimum delay between mutating calls."""

--- a/plynth/engine/api_base.py
+++ b/plynth/engine/api_base.py
@@ -94,8 +94,13 @@ class GitHubClient:
 
     @property
     def is_ghes(self) -> bool:
-        """True if the target is a GHES instance (not github.com / api.github.com)."""
-        return self.target not in ("", "github.com", "https://api.github.com")
+        """True if the target is a GHES instance (not github.com / api.github.com).
+
+        Normalizes the trailing slash to match `derive_api_roots`, which
+        tolerates `github.com/` and `https://api.github.com/`. Without this,
+        the trailing-slash variants would route to `/meta` probing.
+        """
+        return self.target.rstrip("/") not in ("", "github.com", "https://api.github.com")
 
     def warn_if_below(
         self,

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -31,7 +31,11 @@ class RESTClient:
         url = f"{self.base.rest_base}/meta"
         try:
             response = self.base.session.get(url, timeout=self.base.request_timeout_s)
-        except (requests.Timeout, requests.ConnectionError) as e:
+        except requests.RequestException as e:
+            # Detection is informational and must not abort startup. Catch the
+            # full requests hierarchy (Timeout, ConnectionError, SSLError,
+            # InvalidURL, …) so any transport-layer failure produces a warning
+            # and a None version, not a stack trace from `plynth create`.
             if log is not None:
                 log.warning(f"Could not reach {url} for version detection: {e}")
             return

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import requests
 
 from plynth.engine.api_base import GitHubClient
@@ -11,6 +13,55 @@ class RESTClient:
 
     def __init__(self, base: GitHubClient) -> None:
         self.base = base
+
+    def detect_installed_version(self, log: logging.Logger | None = None) -> None:
+        """GET `{rest_base}/meta` and cache the parsed version on `base`.
+
+        No-op for github.com targets — `/meta` exists but doesn't return an
+        installed_version, and version-gating against github.com is meaningless
+        anyway (it always has the latest features). For GHES targets, sets
+        `base.installed_version` to a `(major, minor)` tuple, or leaves it None
+        on any kind of failure (network, non-2xx, missing/malformed field).
+        Failures are logged at WARNING but never raised: version detection is
+        informational, not gating.
+        """
+        if not self.base.is_ghes:
+            return
+
+        url = f"{self.base.rest_base}/meta"
+        try:
+            response = self.base.session.get(url, timeout=self.base.request_timeout_s)
+        except (requests.Timeout, requests.ConnectionError) as e:
+            if log is not None:
+                log.warning(f"Could not reach {url} for version detection: {e}")
+            return
+
+        if not response.ok:
+            if log is not None:
+                log.warning(
+                    f"{url} returned HTTP {response.status_code}; skipping version detection."
+                )
+            return
+
+        try:
+            raw = response.json().get("installed_version")
+        except ValueError:
+            if log is not None:
+                log.warning(f"{url} returned non-JSON body; skipping version detection.")
+            return
+
+        parsed = _parse_version(raw)
+        if parsed is None:
+            if log is not None:
+                log.warning(
+                    f"{url} response missing or malformed installed_version "
+                    f"(got {raw!r}); skipping version detection."
+                )
+            return
+
+        self.base.installed_version = parsed
+        if log is not None:
+            log.info(f"Detected GHES {parsed[0]}.{parsed[1]} at {self.base.display_target}")
 
     def create_milestone(
         self,
@@ -122,3 +173,20 @@ class RESTClient:
         raise NetworkError(
             f"Max retries ({self.base.max_retries}) exceeded creating repo '{org}/{name}'"
         )
+
+
+def _parse_version(raw: object) -> tuple[int, int] | None:
+    """Parse a `installed_version` string ("3.20.1") to `(major, minor)`.
+
+    Patch is ignored — feature gating runs at minor granularity. Anything
+    not parseable returns None.
+    """
+    if not isinstance(raw, str):
+        return None
+    parts = raw.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except ValueError:
+        return None

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -43,6 +43,63 @@ def test_endpoints_for_ghes() -> None:
     assert client.display_target == "https://ghes.example.com"
 
 
+@pytest.mark.parametrize(
+    "target,expected_is_ghes",
+    [
+        ("", False),
+        ("github.com", False),
+        ("https://api.github.com", False),
+        ("https://ghes.example.com", True),
+        ("https://github.acme.internal", True),
+    ],
+)
+def test_is_ghes(target: str, expected_is_ghes: bool) -> None:
+    assert GitHubClient(target, "tok", write_delay_ms=0).is_ghes is expected_is_ghes
+
+
+def test_installed_version_starts_none() -> None:
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+    assert client.installed_version is None
+
+
+def test_warn_if_below_warns_when_below(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+    client.installed_version = (3, 19)
+    log = logging.getLogger("plynth.test.warn_if_below_below")
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        client.warn_if_below((3, 20), "views API", log)
+    msgs = [r.message for r in caplog.records if r.name == log.name]
+    assert any("requires GHES 3.20+" in m and "detected 3.19" in m for m in msgs)
+
+
+def test_warn_if_below_silent_when_at_or_above(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+    log = logging.getLogger("plynth.test.warn_if_below_above")
+
+    for version in [(3, 20), (3, 21), (4, 0)]:
+        client.installed_version = version
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger=log.name):
+            client.warn_if_below((3, 20), "views API", log)
+        assert [r for r in caplog.records if r.name == log.name] == []
+
+
+def test_warn_if_below_silent_when_version_unknown(caplog: pytest.LogCaptureFixture) -> None:
+    """github.com (None) and detection failures (also None) must not warn."""
+    import logging
+
+    client = GitHubClient("github.com", "tok", write_delay_ms=0)
+    assert client.installed_version is None
+    log = logging.getLogger("plynth.test.warn_if_below_unknown")
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        client.warn_if_below((3, 20), "views API", log)
+    assert [r for r in caplog.records if r.name == log.name] == []
+
+
 def test_ghesclient_alias_emits_deprecation_warning() -> None:
     with pytest.warns(DeprecationWarning, match="GHESClient is deprecated"):
         client = GHESClient("https://ghes.example.com", "tok", write_delay_ms=0)

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -48,8 +48,11 @@ def test_endpoints_for_ghes() -> None:
     [
         ("", False),
         ("github.com", False),
+        ("github.com/", False),  # trailing slash tolerated by derive_api_roots
         ("https://api.github.com", False),
+        ("https://api.github.com/", False),  # same
         ("https://ghes.example.com", True),
+        ("https://ghes.example.com/", True),
         ("https://github.acme.internal", True),
     ],
 )

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 import requests
 import responses
 
 from plynth.engine.api_base import GitHubClient
-from plynth.engine.rest_client import RESTClient
+from plynth.engine.rest_client import RESTClient, _parse_version
 from plynth.errors import AuthError, NotFoundError
 
 GHES_URL = "https://ghes.example.com"
 MILESTONE_URL = f"{GHES_URL}/api/v3/repos/example-org/acme/milestones"
 ORG_REPOS_URL = f"{GHES_URL}/api/v3/orgs/example-org/repos"
+META_URL = f"{GHES_URL}/api/v3/meta"
 
 
 def _client() -> RESTClient:
@@ -119,3 +121,109 @@ def test_create_repo_422_raises() -> None:
     )
     with pytest.raises(requests.HTTPError):
         _client().create_repo(org="example-org", name="acme")
+
+
+# ── /meta version detection ───────────────────────────────────
+
+
+@responses.activate
+def test_detect_installed_version_ghes_happy_path(caplog: pytest.LogCaptureFixture) -> None:
+    responses.add(
+        responses.GET,
+        META_URL,
+        json={"installed_version": "3.20.1", "verifiable_password_authentication": False},
+        status=200,
+    )
+    client = _client()
+    log = logging.getLogger("plynth.test.detect_happy")
+    with caplog.at_level(logging.INFO, logger=log.name):
+        client.detect_installed_version(log)
+
+    assert client.base.installed_version == (3, 20)
+    msgs = [r.message for r in caplog.records if r.name == log.name]
+    assert any("Detected GHES 3.20" in m for m in msgs)
+
+
+def test_detect_installed_version_github_com_skips() -> None:
+    """github.com targets must not call /meta and must leave installed_version None."""
+    base = GitHubClient("github.com", "tok", write_delay_ms=0)
+    rest = RESTClient(base)
+
+    @responses.activate
+    def _run() -> None:
+        # If detect_installed_version did issue a request, `responses` would
+        # raise ConnectionError because no mock is registered.
+        rest.detect_installed_version(logging.getLogger("plynth.test.detect_dotcom"))
+
+    _run()
+    assert base.installed_version is None
+
+
+@responses.activate
+def test_detect_installed_version_404_logs_and_leaves_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses.add(responses.GET, META_URL, json={"message": "Not Found"}, status=404)
+    client = _client()
+    log = logging.getLogger("plynth.test.detect_404")
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        client.detect_installed_version(log)
+
+    assert client.base.installed_version is None
+    msgs = [r.message for r in caplog.records if r.name == log.name]
+    assert any("HTTP 404" in m for m in msgs)
+
+
+@responses.activate
+def test_detect_installed_version_missing_field_logs_and_leaves_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses.add(responses.GET, META_URL, json={"ssh_key_fingerprints": {}}, status=200)
+    client = _client()
+    log = logging.getLogger("plynth.test.detect_missing_field")
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        client.detect_installed_version(log)
+
+    assert client.base.installed_version is None
+    msgs = [r.message for r in caplog.records if r.name == log.name]
+    assert any("missing or malformed installed_version" in m for m in msgs)
+
+
+@responses.activate
+def test_detect_installed_version_timeout_logs_and_leaves_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses.add(responses.GET, META_URL, body=requests.Timeout("read timeout"))
+    client = _client()
+    log = logging.getLogger("plynth.test.detect_timeout")
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        client.detect_installed_version(log)
+
+    assert client.base.installed_version is None
+    msgs = [r.message for r in caplog.records if r.name == log.name]
+    assert any("Could not reach" in m for m in msgs)
+
+
+def test_detect_installed_version_silent_without_logger() -> None:
+    """Calling without a logger must not raise; the caller may not have one yet."""
+    base = GitHubClient("github.com", "tok", write_delay_ms=0)
+    RESTClient(base).detect_installed_version()
+    assert base.installed_version is None
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("3.20.1", (3, 20)),
+        ("3.20", (3, 20)),
+        ("3.20.1-rc1", (3, 20)),  # patch ignored, prerelease tolerated
+        ("4.0.0", (4, 0)),
+        ("3", None),
+        ("", None),
+        ("not-a-version", None),
+        (None, None),
+        (320, None),  # non-string
+    ],
+)
+def test_parse_version(raw: object, expected: tuple[int, int] | None) -> None:
+    assert _parse_version(raw) == expected

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -189,13 +189,25 @@ def test_detect_installed_version_missing_field_logs_and_leaves_none(
     assert any("missing or malformed installed_version" in m for m in msgs)
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        requests.Timeout("read timeout"),
+        requests.ConnectionError("connection refused"),
+        requests.exceptions.SSLError("certificate verify failed"),
+        requests.exceptions.InvalidURL("bad url"),
+    ],
+    ids=["timeout", "connection", "ssl", "invalid_url"],
+)
 @responses.activate
-def test_detect_installed_version_timeout_logs_and_leaves_none(
-    caplog: pytest.LogCaptureFixture,
+def test_detect_installed_version_transport_errors_logged_not_raised(
+    exc: Exception, caplog: pytest.LogCaptureFixture
 ) -> None:
-    responses.add(responses.GET, META_URL, body=requests.Timeout("read timeout"))
+    """Detection is informational: any requests transport failure must yield
+    a warning and a None version, never propagate."""
+    responses.add(responses.GET, META_URL, body=exc)
     client = _client()
-    log = logging.getLogger("plynth.test.detect_timeout")
+    log = logging.getLogger("plynth.test.detect_transport")
     with caplog.at_level(logging.WARNING, logger=log.name):
         client.detect_installed_version(log)
 


### PR DESCRIPTION
Closes #15.

## What changed

`GitHubClient` carries an `installed_version: (major, minor) | None` and an `is_ghes` property. `RESTClient.detect_installed_version(log)` probes `{rest_base}/meta` on GHES targets, parses `installed_version` from the response (patch ignored), and caches the tuple on the base client. The CLI calls it once during `create` and `resolve` startup, after the clients are wired up.

`GitHubClient.warn_if_below(min_version, feature, log)` is the gate helper. It warns when the version is known and below the minimum, and stays silent when the version is `None` (covers both github.com and detection failures, without double-logging). No call sites yet — wiring lands when view automation does in a later PR.

## Behavior matrix

| Target | `/meta` call | `installed_version` |
| --- | --- | --- |
| `github.com` / `https://api.github.com` / `""` | skipped | `None` (treated as latest) |
| GHES, 200 with `installed_version: "3.20.1"` | issued | `(3, 20)` |
| GHES, 404 / non-2xx | issued | `None`, warning logged |
| GHES, network error | issued | `None`, warning logged |
| GHES, missing or malformed field | issued | `None`, warning logged |

Detection is **informational**, never raising. Gating belongs at the feature call site.

## Sequencing

Unblocks #40 (the 401 error message can now be conditional on detected version).

## Tests

- `tests/test_rest_client.py`: happy path (`3.20.1` → `(3, 20)`), github.com skip (no HTTP request issued), 404 / timeout / missing-field paths, `_parse_version` parametrized table including `3.20.1-rc1`, missing minor, non-strings.
- `tests/test_api_base.py`: `is_ghes` parametrized, `warn_if_below` below / equal / above / unknown cases.
- Full suite: 186 passed, 2 skipped (pre-existing POSIX-only).
- `ruff check`, `ruff format --check`, `mypy plynth` all clean.
