### PR TITLE
feat(cli): JSON dry-run output (--dry-run --format json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **JSON dry-run output** (#12). `plynth create --dry-run --format json`
+  emits the resolved `ExecutionPlan` plus an `api_call_estimate` block
+  as a JSON document with a stable `schema_version`. Lets CI plan
+  diffs, bot summaries, and other tooling consume the plan
+  programmatically instead of regex-scraping the text formatter.
+  Default remains `--format text`. Schema documented in
+  [docs/dry-run-json.md](docs/dry-run-json.md); the
+  `api_call_estimate` keys are pinned by a test so accidental renames
+  force a `schema_version` bump.
 - **Rich field option objects** (#42). Single-select field options can now
   declare `color`, `description`, `default`, `aliases`, and `deprecated` as
   an object instead of a plain string. Plain strings still work; the two

--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ Build in this order. Each step should be testable independently.
    - Resume logic: check state file phases, skip completed phases
 
 6. **CLI** (`cli.py`)
-   - `plynth create --template <path> --instance <path> [--dry-run]`
+   - `plynth create --template <path> --instance <path> [--dry-run [--format text|json]]`
    - `plynth resolve --state <path>` (re-run Phase 5 only)
    - Auth via `PLYNTH_TOKEN` env var or `--token` flag
+   - JSON dry-run: stable schema for piping plans into other tools.
+     See [docs/dry-run-json.md](docs/dry-run-json.md).
 
 ## What NOT to build in Phase B
 
@@ -262,5 +264,7 @@ Browse open issues by area:
 - [Good first issues](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22good-first-issue%22)
 - [Help wanted](https://github.com/Declaratus/plynth/issues?q=is%3Aissue+is%3Aopen+label%3A%22help-wanted%22)
 
-Recent themes: github.com support and PyPI publishing (v0.3.0); drift
-detection, JSON dry-run output, and a GitHub Action wrapper (post-0.3).
+Recent themes: github.com support and PyPI publishing (v0.3.0); rich
+field options, repo creation, GHES version detection, and JSON
+dry-run output (v0.4.0); drift detection and a GitHub Action wrapper
+remain on the post-0.4 list.

--- a/docs/dry-run-json.md
+++ b/docs/dry-run-json.md
@@ -1,0 +1,82 @@
+# JSON dry-run output
+
+`plynth create --dry-run --format json` emits the resolved
+[`ExecutionPlan`](../plynth/models/plan.py) plus a count of mutating
+API calls plynth would make. The shape is stable within a major
+`schema_version` so downstream tools (CI plan diffs, bot summaries,
+custom dashboards) can pin to it.
+
+## Top-level shape
+
+```json
+{
+  "schema_version": 1,
+  "plynth_version": "0.4.0",
+  "plan": { ... },
+  "api_call_estimate": { ... }
+}
+```
+
+| Field               | Type   | Notes                                                                                  |
+| ------------------- | ------ | -------------------------------------------------------------------------------------- |
+| `schema_version`    | int    | Bumped on breaking shape changes. Additive fields don't change it.                     |
+| `plynth_version`    | string | The CLI version that produced the payload, from `importlib.metadata`.                  |
+| `plan`              | object | The full `ExecutionPlan` (Pydantic `model_dump(mode="json")`).                         |
+| `api_call_estimate` | object | Per-category counts plus a `total`; matches the figures in the text dry-run footer.    |
+
+## `plan` block
+
+A direct dump of the `ExecutionPlan` Pydantic model. Today's keys:
+
+- `template_name`, `template_version`
+- `instance_org`, `instance_repo`, `instance_repo_create`
+- `target` (display: `""` and `"github.com"` are equivalent for the
+  github.com target)
+- `project_name`, `project_description`
+- `status_options` (list of status options)
+- `fields` (list of `ResolvedField`: `id`, `name`, `type`,
+  `options[].{value,color,description,default}`)
+- `milestones` (list of `ResolvedMilestone`)
+- `issues` (list of `ResolvedIssue`)
+- `views` (list of `ViewDefinition`)
+- `placeholder_values` (object: name → resolved value)
+- `skipped_milestones`, `skipped_issues` (lists of IDs)
+- `warnings` (list of strings)
+
+Adding a new field to `ExecutionPlan` is non-breaking. Renaming or
+removing one bumps `schema_version`.
+
+## `api_call_estimate` block
+
+```json
+{
+  "milestones": 5,
+  "issues_create": 17,
+  "add_to_project": 17,
+  "field_values": 51,
+  "body_updates": 17,
+  "dependencies": 12,
+  "total": 119
+}
+```
+
+`total` is the sum of the other six. The keys are pinned by a test
+(`test_api_call_estimate_keys_and_total`) so accidental renames force
+a `schema_version` bump.
+
+## Stability policy
+
+- **Additive change (no bump):** new optional field on `plan` or
+  `api_call_estimate`. Consumers that ignore unknown keys keep working.
+- **Breaking change (bump `schema_version`):** rename, remove, or
+  retype any field; change semantics of an existing field.
+
+Pin to the major `schema_version` you tested against and skip payloads
+with a higher one if you can't validate the shape yourself.
+
+## Example consumer
+
+```bash
+plynth create --template t.yaml --instance i.yaml --dry-run --format json \
+  | jq '.api_call_estimate.total'
+```

--- a/docs/dry-run-json.md
+++ b/docs/dry-run-json.md
@@ -20,7 +20,7 @@ custom dashboards) can pin to it.
 | Field               | Type   | Notes                                                                                  |
 | ------------------- | ------ | -------------------------------------------------------------------------------------- |
 | `schema_version`    | int    | Bumped on breaking shape changes. Additive fields don't change it.                     |
-| `plynth_version`    | string | The CLI version that produced the payload, from `importlib.metadata`.                  |
+| `plynth_version`    | string | The installed CLI version, from `importlib.metadata.version("plynth")` (`"0.0.0"` if metadata is unavailable). |
 | `plan`              | object | The full `ExecutionPlan` (Pydantic `model_dump(mode="json")`).                         |
 | `api_call_estimate` | object | Per-category counts plus a `total`; matches the figures in the text dry-run footer.    |
 

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 from plynth.engine.api_base import GitHubClient
 from plynth.engine.graphql_client import GraphQLClient
 from plynth.engine.phases import PhaseOrchestrator
-from plynth.engine.planner import format_dry_run, plan
+from plynth.engine.planner import format_dry_run, format_dry_run_json, plan
 from plynth.engine.rest_client import RESTClient
 from plynth.errors import ConfigError, PlynthError
 from plynth.models.instance import InstanceConfig
@@ -75,6 +75,13 @@ def build_parser() -> argparse.ArgumentParser:
     create_parser.add_argument("--instance", required=True, help="Path to instance config YAML")
     create_parser.add_argument(
         "--dry-run", action="store_true", help="Print plan without executing"
+    )
+    create_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Dry-run output format (default: text). 'json' emits a stable "
+        "schema documented in docs/dry-run-json.md.",
     )
     create_parser.add_argument(
         "--token",
@@ -150,7 +157,10 @@ def _cmd_create(args: argparse.Namespace, log: logging.Logger) -> None:
 
     # 3. Dry run?
     if args.dry_run:
-        print(format_dry_run(execution_plan))
+        if args.format == "json":
+            print(format_dry_run_json(execution_plan))
+        else:
+            print(format_dry_run(execution_plan))
         return
 
     # 4. Get token

--- a/plynth/cli.py
+++ b/plynth/cli.py
@@ -128,6 +128,11 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
+    # --format only makes sense with --dry-run; reject early so the
+    # flag isn't silently ignored on the execution path.
+    if args.command == "create" and args.format != "text" and not args.dry_run:
+        parser.error("--format only applies to --dry-run")
+
     # Configure logging
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import re
 from datetime import date, timedelta
+from importlib import metadata
 from typing import Any
 
-from plynth import __version__ as _plynth_version
 from plynth.models.instance import InstanceConfig
 from plynth.models.plan import (
     ExecutionPlan,
@@ -299,17 +299,13 @@ def format_dry_run(ep: ExecutionPlan) -> str:
 
     # API call estimate
     est = api_call_estimate(ep)
-    n_issues = est["issues_create"]
     total = est["total"]
 
     w("API call estimate:")
     w(f"  Milestones:     {est['milestones']} REST calls")
     w(f"  Issues:         {est['issues_create']} GraphQL createIssue calls")
     w(f"  Add to project: {est['add_to_project']} GraphQL addProjectV2ItemById calls")
-    w(
-        f"  Field values:   {est['field_values']} GraphQL updateProjectV2ItemFieldValue calls"
-        f" ({n_issues} issues \u00d7 {len(ep.fields)} fields)"
-    )
+    w(f"  Field values:   {est['field_values']} GraphQL updateProjectV2ItemFieldValue calls")
     w(f"  Body updates:   {est['body_updates']} GraphQL updateIssue calls (cross-ref resolution)")
     w(f"  Dependencies:   {est['dependencies']} GraphQL addBlockedBy calls")
     w(f"  Total:          ~{total} mutating calls (~{total}s at 1s delay)")
@@ -349,9 +345,13 @@ def dry_run_json_payload(ep: ExecutionPlan) -> dict[str, Any]:
     ``plan`` block is the ExecutionPlan dumped by Pydantic, so any new
     field added to ``ExecutionPlan`` shows up automatically.
     """
+    try:
+        plynth_version = metadata.version("plynth")
+    except metadata.PackageNotFoundError:
+        plynth_version = "0.0.0"
     return {
         "schema_version": DRY_RUN_JSON_SCHEMA_VERSION,
-        "plynth_version": _plynth_version,
+        "plynth_version": plynth_version,
         "plan": ep.model_dump(mode="json"),
         "api_call_estimate": api_call_estimate(ep),
     }

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import re
 from datetime import date, timedelta
+from typing import Any
 
+from plynth import __version__ as _plynth_version
 from plynth.models.instance import InstanceConfig
 from plynth.models.plan import (
     ExecutionPlan,
@@ -12,6 +15,10 @@ from plynth.models.plan import (
     ResolvedMilestone,
 )
 from plynth.models.template import TemplateDefinition
+
+# Stable schema version for the JSON dry-run payload. Bump on
+# breaking shape changes; document in docs/dry-run-json.md.
+DRY_RUN_JSON_SCHEMA_VERSION = 1
 
 # Matches {PREFIX}-### patterns in issue bodies (cross-references).
 _CROSSREF_RE = re.compile(r"\{PREFIX\}-(\d{3})")
@@ -291,6 +298,31 @@ def format_dry_run(ep: ExecutionPlan) -> str:
         w("")
 
     # API call estimate
+    est = api_call_estimate(ep)
+    n_issues = est["issues_create"]
+    total = est["total"]
+
+    w("API call estimate:")
+    w(f"  Milestones:     {est['milestones']} REST calls")
+    w(f"  Issues:         {est['issues_create']} GraphQL createIssue calls")
+    w(f"  Add to project: {est['add_to_project']} GraphQL addProjectV2ItemById calls")
+    w(
+        f"  Field values:   {est['field_values']} GraphQL updateProjectV2ItemFieldValue calls"
+        f" ({n_issues} issues \u00d7 {len(ep.fields)} fields)"
+    )
+    w(f"  Body updates:   {est['body_updates']} GraphQL updateIssue calls (cross-ref resolution)")
+    w(f"  Dependencies:   {est['dependencies']} GraphQL addBlockedBy calls")
+    w(f"  Total:          ~{total} mutating calls (~{total}s at 1s delay)")
+
+    return "\n".join(lines)
+
+
+def api_call_estimate(ep: ExecutionPlan) -> dict[str, int]:
+    """Counts of mutating API calls plynth will make for *ep*.
+
+    Shared by the text and JSON dry-run formatters; the keys are part
+    of the JSON dry-run schema (see ``docs/dry-run-json.md``).
+    """
     n_issues = len(ep.issues)
     n_milestones = len(ep.milestones)
     n_field_values = sum(len(i.fields) for i in ep.issues)
@@ -298,17 +330,33 @@ def format_dry_run(ep: ExecutionPlan) -> str:
     n_body_updates = n_issues
     n_add_to_project = n_issues
     total = n_milestones + n_issues + n_add_to_project + n_field_values + n_body_updates + n_deps
+    return {
+        "milestones": n_milestones,
+        "issues_create": n_issues,
+        "add_to_project": n_add_to_project,
+        "field_values": n_field_values,
+        "body_updates": n_body_updates,
+        "dependencies": n_deps,
+        "total": total,
+    }
 
-    w("API call estimate:")
-    w(f"  Milestones:     {n_milestones} REST calls")
-    w(f"  Issues:         {n_issues} GraphQL createIssue calls")
-    w(f"  Add to project: {n_add_to_project} GraphQL addProjectV2ItemById calls")
-    w(
-        f"  Field values:   {n_field_values} GraphQL updateProjectV2ItemFieldValue calls"
-        f" ({n_issues} issues \u00d7 {len(ep.fields)} fields)"
-    )
-    w(f"  Body updates:   {n_body_updates} GraphQL updateIssue calls (cross-ref resolution)")
-    w(f"  Dependencies:   {n_deps} GraphQL addBlockedBy calls")
-    w(f"  Total:          ~{total} mutating calls (~{total}s at 1s delay)")
 
-    return "\n".join(lines)
+def dry_run_json_payload(ep: ExecutionPlan) -> dict[str, Any]:
+    """Return the JSON dry-run payload as a plain dict.
+
+    Schema is stable within a major ``schema_version``; additive fields
+    are non-breaking, renames or removals bump the version. The
+    ``plan`` block is the ExecutionPlan dumped by Pydantic, so any new
+    field added to ``ExecutionPlan`` shows up automatically.
+    """
+    return {
+        "schema_version": DRY_RUN_JSON_SCHEMA_VERSION,
+        "plynth_version": _plynth_version,
+        "plan": ep.model_dump(mode="json"),
+        "api_call_estimate": api_call_estimate(ep),
+    }
+
+
+def format_dry_run_json(ep: ExecutionPlan) -> str:
+    """Return the dry-run plan as a JSON string (2-space indent, sorted keys off)."""
+    return json.dumps(dry_run_json_payload(ep), indent=2, ensure_ascii=False)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -123,3 +123,43 @@ def test_write_delay_ms_rejects_above_upper_bound() -> None:
         parser.parse_args(
             ["create", "--template", "t.yaml", "--instance", "i.yaml", "--write-delay-ms", "30001"]
         )
+
+
+def test_format_defaults_to_text() -> None:
+    parser = build_parser()
+    ns = parser.parse_args(["create", "--template", "t.yaml", "--instance", "i.yaml", "--dry-run"])
+    assert ns.format == "text"
+
+
+def test_format_accepts_json() -> None:
+    parser = build_parser()
+    ns = parser.parse_args(
+        [
+            "create",
+            "--template",
+            "t.yaml",
+            "--instance",
+            "i.yaml",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+    assert ns.format == "json"
+
+
+def test_format_rejects_unknown_value() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "create",
+                "--template",
+                "t.yaml",
+                "--instance",
+                "i.yaml",
+                "--dry-run",
+                "--format",
+                "yaml",
+            ]
+        )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -194,3 +194,32 @@ def test_cli_main_exits_2_on_plynth_error(
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
     assert "Error: Template file not found" in captured.err
+
+
+def test_cli_main_rejects_format_json_without_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--format json` without `--dry-run` is a usage error, not a silent no-op."""
+    from plynth import cli
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "plynth",
+            "create",
+            "--template",
+            "tests/fixtures/minimal-template.yaml",
+            "--instance",
+            "tests/fixtures/minimal-instance.yaml",
+            "--format",
+            "json",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    # parser.error exits with code 2 and writes to stderr.
+    assert exc_info.value.code == 2
+    assert "--format only applies to --dry-run" in capsys.readouterr().err

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from plynth.engine.planner import format_dry_run, plan, resolve_placeholders
+from plynth.engine.planner import (
+    DRY_RUN_JSON_SCHEMA_VERSION,
+    api_call_estimate,
+    dry_run_json_payload,
+    format_dry_run,
+    format_dry_run_json,
+    plan,
+    resolve_placeholders,
+)
 from plynth.models.instance import InstanceConfig
 from plynth.models.template import TemplateDefinition
 
@@ -235,3 +245,83 @@ def test_plan_unknown_value_via_instance_override_rejected(
     minimal_instance.field_overrides = {tid: {"priority": "BadOverride"}}
     with pytest.raises(ValueError, match="not a declared option"):
         plan(minimal_template, minimal_instance)
+
+
+# ── M2: JSON dry-run output ───────────────────────────────────────
+
+
+def test_api_call_estimate_keys_and_total(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    est = api_call_estimate(ep)
+    # Keys are part of the JSON dry-run schema; pin them so accidental
+    # renames here force a schema_version bump.
+    assert set(est.keys()) == {
+        "milestones",
+        "issues_create",
+        "add_to_project",
+        "field_values",
+        "body_updates",
+        "dependencies",
+        "total",
+    }
+    assert est["total"] == (
+        est["milestones"]
+        + est["issues_create"]
+        + est["add_to_project"]
+        + est["field_values"]
+        + est["body_updates"]
+        + est["dependencies"]
+    )
+
+
+def test_dry_run_json_payload_top_level_keys(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    payload = dry_run_json_payload(ep)
+    assert set(payload.keys()) == {
+        "schema_version",
+        "plynth_version",
+        "plan",
+        "api_call_estimate",
+    }
+    assert payload["schema_version"] == DRY_RUN_JSON_SCHEMA_VERSION
+
+
+def test_dry_run_json_payload_plan_block_matches_execution_plan(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    payload = dry_run_json_payload(ep)
+    plan_block = payload["plan"]
+    # Spot-check that the ExecutionPlan dump round-trips through the payload.
+    assert plan_block["template_name"] == ep.template_name
+    assert plan_block["project_name"] == ep.project_name
+    assert plan_block["instance_org"] == ep.instance_org
+    assert plan_block["instance_repo"] == ep.instance_repo
+    assert len(plan_block["issues"]) == len(ep.issues)
+    assert len(plan_block["milestones"]) == len(ep.milestones)
+    assert len(plan_block["fields"]) == len(ep.fields)
+
+
+def test_format_dry_run_json_is_valid_json_and_round_trips(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    out = format_dry_run_json(ep)
+    parsed = json.loads(out)
+    assert parsed == dry_run_json_payload(ep)
+
+
+def test_format_dry_run_json_includes_warnings_when_present(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    # Skip a milestone that issues depend on so the planner emits warnings.
+    minimal_instance.skip_milestones = [minimal_template.milestones[0].id]
+    ep = plan(minimal_template, minimal_instance)
+    payload = dry_run_json_payload(ep)
+    assert isinstance(payload["plan"]["warnings"], list)
+    # Warnings list mirrors the ExecutionPlan one-to-one.
+    assert payload["plan"]["warnings"] == ep.warnings


### PR DESCRIPTION
Closes #12.

`plynth create --dry-run --format json` emits the resolved
ExecutionPlan plus an `api_call_estimate` block as a JSON document
with a stable `schema_version`, so CI plan diffs and bot summaries
can consume plans programmatically instead of regex-scraping the
text formatter.

Default stays `--format text`. Schema documented in
[docs/dry-run-json.md](docs/dry-run-json.md); `api_call_estimate`
keys are pinned by a test so accidental renames force a
`schema_version` bump.

## Schema (v1)

- `schema_version` (int) — bumped on breaking shape changes
- `plynth_version` (str) — read from `importlib.metadata`
- `plan` (object) — full `ExecutionPlan` via Pydantic `model_dump`
- `api_call_estimate` (object) — six counts plus `total`

Adding fields to `ExecutionPlan` is non-breaking. Renames or
removals bump `schema_version`.

## Tests

8 new tests in `tests/test_planner.py` and `tests/test_cli_args.py`:

- `--format` defaults to `text`, accepts `json`, rejects unknown values
- `api_call_estimate` keys pinned, `total` = sum of parts
- payload top-level keys pinned
- `plan` block matches `ExecutionPlan`
- `format_dry_run_json` round-trips through `json.loads`
- warnings carry through

200 passed, 0 fail. ruff + ruff-format + mypy clean.

## Out of scope

- `--format json` is dry-run only. The non-dry-run path emits log
  lines, not structured plan output; gating that behind `--format`
  would be a separate change.
- Version bump to 0.4.0 lands with the release commit, not here.