### PR TITLE
feat(engine): configurable Status field options (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   error, malformed response) log a warning and leave the version as
   `None`; nothing fails. Prepares the ground for view-API gating
   (GHES 3.20+) once view automation lands.
+- **Configurable Status field options** (#14). The template-level `status:`
+  block, previously parsed but inert, now drives the project's built-in
+  Status field. plynth overwrites GitHub's defaults (Backlog/Ready/In
+  progress/In review/Done) with the declared list during Phase 1, in the
+  order given. `default: true` on one option picks what new items receive
+  in Phase 4, replacing the hard-coded `Backlog` lookup. Omitting the block
+  keeps GitHub's defaults exactly as before. Status options share the rich
+  `FieldOption` shape introduced in #42 (color, description, default,
+  aliases, deprecated); the older `StatusOption` model is removed.
+  Requires GHES 3.19+ (the `singleSelectOptions` field on
+  `UpdateProjectV2FieldInput` shipped in cloud on 2024-12-12); plynth
+  introspects the schema at the start of Phase 1 and fails with a clear
+  message on older instances. Templates without a `status:` block run on
+  any GHES version plynth otherwise supports. Verified end-to-end against
+  GHES 3.19.4 — the public GraphQL mutation accepts the system Status
+  field and preserves input order (the in-UI Projects settings flow
+  re-sequences, but the API path does not).
 - **Repo creation when `repo.create: true`** (#13). With `repo.create: true`
   in the instance config, Phase 1 creates the target repository (private)
   via REST before resolving its node ID, instead of failing with

--- a/docs/example-template.yaml
+++ b/docs/example-template.yaml
@@ -39,11 +39,18 @@ placeholders:
     required: true
 
 # ─── Status Field ────────────────────────────────────────────────────────────
-# Customizes the built-in Status field on the project board.
-# Option order is preserved (rendered left-to-right on the board).
+# Customizes the built-in Status field on the project board. Plynth
+# overwrites GitHub's default options (Backlog/Ready/In progress/In review/
+# Done) with the list below during Phase 1, before any items exist on the
+# project. Option order is preserved (rendered left-to-right on the board).
+# Mark exactly one option `default: true` to set what new items receive;
+# omitting it falls back to the first option, which the planner will warn
+# about. Requires GHES 3.19+; older instances fail loud at Phase 1 start.
+# Omit the block entirely to keep GitHub's defaults.
 status:
   - value: "Backlog"
     color: "GRAY"
+    default: true
   - value: "Ready"
     color: "BLUE"
   - value: "In Progress"

--- a/docs/options.md
+++ b/docs/options.md
@@ -41,7 +41,7 @@ fields:
 | `value` | string (max 100) | required | Display name on the board. Placeholders resolved at plan time. |
 | `color` | enum | omitted (rendered GRAY) | One of GRAY, BLUE, YELLOW, RED, PURPLE, GREEN, ORANGE, PINK. Anything else fails template validation; add the value to `OptionColor` if a future GHES version introduces a new color. |
 | `description` | string (max 2000) | "" | Tooltip text shown on hover in the project board. |
-| `default` | bool | false | At most one option per field may be `default: true`. Reserved for future "set on item creation" behavior; currently informational. |
+| `default` | bool | false | At most one option per field may be `default: true`. On the `status:` block, controls what new items receive in Phase 4 (see [Status field](#status-field) below). Informational on custom fields until per-issue field defaults land. |
 | `aliases` | list[string] | [] | Reserved for future option-rename reconciliation. Currently informational. |
 | `deprecated` | bool | false | Marks an option as legacy. Currently informational. |
 
@@ -59,17 +59,25 @@ Pick colors per field as a categorical scale. Avoid two adjacent option values s
 - **gray** — neutral / N/A / not yet triaged
 - **blue / purple / orange / pink** — categorical distinctions where the semantics above don't apply
 
-A worked example for a Status field:
+## Status field
+
+The top-level `status:` block configures the project's built-in Status field. It accepts the same option shape as a custom field's `options:`, plus the `default: true` flag selects which option is applied to new items in Phase 4.
 
 ```yaml
 status:
-  - { value: "Backlog",     color: GRAY }
-  - { value: "Ready",       color: BLUE }
-  - { value: "In Progress", color: YELLOW }
-  - { value: "Blocked",     color: RED }
-  - { value: "In Review",   color: PURPLE }
+  - { value: "Triaged",     color: GRAY,   default: true }
+  - { value: "Spec'd",      color: BLUE }
+  - { value: "In progress", color: YELLOW }
+  - { value: "In review",   color: PURPLE }
   - { value: "Done",        color: GREEN }
 ```
+
+Behavior:
+
+- **Order is preserved.** plynth sends the list in declaration order and GHES 3.19+ honors it (verified end-to-end against the public `updateProjectV2Field` mutation; the in-UI Projects settings flow re-sequences, but the API path does not).
+- **Replace, not patch.** plynth overwrites GitHub's defaults (Backlog/Ready/In progress/In review/Done) wholesale. Safe at bootstrap because no items exist on the project yet — see "full-list replacements" below.
+- **Default selection.** Mark exactly one option `default: true` to pick what new items receive in Phase 4. If no option is marked, the planner emits a warning and falls back to the first option in display order. Omit the whole `status:` block to keep GitHub's defaults, in which case plynth applies `Backlog` to new items as it always has.
+- **GHES floor.** Configurable Status requires GHES 3.19+ (the `singleSelectOptions` field on `UpdateProjectV2FieldInput` shipped in cloud on 2024-12-12). plynth probes the schema at the start of Phase 1 and fails with a clear message on older instances. Templates without a `status:` block run on any GHES version plynth otherwise supports.
 
 ## Critical: option mutations are full-list replacements
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -64,7 +64,7 @@ class ExecutionPlan(BaseModel):
     project_description: str
     
     # Resolved resources
-    status_options: list[StatusOption]       # From template, unchanged
+    status_options: list[ResolvedFieldOption]  # From template, placeholder-resolved (drives updateProjectV2Field on system Status)
     fields: list[ResolvedField]
     milestones: list[ResolvedMilestone]
     issues: list[ResolvedIssue]

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -137,6 +137,45 @@ class GraphQLClient:
         data = self.execute(mutations.CREATE_FIELD, variables, is_mutation=True)
         return data["createProjectV2Field"]["projectV2Field"]
 
+    def supports_status_overwrite(self) -> bool:
+        """Return True iff the target's UpdateProjectV2FieldInput carries
+        ``singleSelectOptions``.
+
+        Cloud added it on 2024-12-12 and GHES 3.19+ ships it. The probe is a
+        plain GraphQL introspection — works without project scopes — so it can
+        front-run the actual mutation and turn an unsupported instance into a
+        clear "needs 3.19+" error rather than a 422 during Phase 1.
+        """
+        data = self.execute(queries.INTROSPECT_UPDATE_FIELD_INPUT)
+        type_info = data.get("__type") or {}
+        input_fields = type_info.get("inputFields") or []
+        return any(f.get("name") == "singleSelectOptions" for f in input_fields)
+
+    # CRITICAL: same replace-the-list semantics as ``create_field``. Whatever
+    # ``options`` you pass becomes the new option list verbatim — anything
+    # omitted is deleted, and any item value pointing at a deleted option is
+    # cleared. Plynth's Phase 1 calls this before any items exist on the
+    # project, so nothing is at risk; reconciliation paths must read the
+    # existing options and merge before writing.
+    def update_field_options(self, field_id: str, options: list[dict]) -> list[dict]:
+        """Overwrite the option list on an existing single-select field.
+
+        ``options`` items are ``{"name", "color", "description"}`` dicts in
+        the order the operator wants them displayed (the GraphQL mutation
+        preserves input order on the system Status field, verified against
+        GHES 3.19.4 — see canary in ``.import/single-select-research/``).
+
+        Returns the server's new option list, including freshly-issued
+        option IDs. Callers should consume these directly rather than
+        re-querying — option IDs rotate on every overwrite.
+        """
+        data = self.execute(
+            mutations.UPDATE_FIELD_OPTIONS,
+            {"fieldId": field_id, "options": options},
+            is_mutation=True,
+        )
+        return data["updateProjectV2Field"]["projectV2Field"].get("options", [])
+
     def get_project_fields(self, project_id: str) -> list[dict]:
         """Re-query all fields on a project to get field IDs and option IDs.
 

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -109,15 +109,12 @@ class PhaseOrchestrator:
     def phase_1_create_project_and_fields(self) -> None:
         """Create project, custom fields, and resolve field/option IDs."""
 
-        # 1a. Resolve org and repo IDs
-        org_id = self.gql.get_org_id(self.plan.instance_org)
-        repo_id = self._resolve_repo_id()
-        self.state.repo = RepoState(name=self.plan.instance_repo, node_id=repo_id)
-
         # If the template configures custom Status options, gate on the
-        # GraphQL surface being present *before* creating anything. A 3.18
-        # instance would otherwise leave an orphan project behind when the
-        # mutation 422s mid-phase.
+        # GraphQL surface being present *before any side effects*. The probe
+        # is pure schema introspection and runs ahead of org/repo resolution
+        # so that a 3.18 instance never reaches `_resolve_repo_id()` (which
+        # creates the repo when `repo.create: true`) — no orphan repos and no
+        # orphan projects.
         if self.plan.status_options and not self.gql.supports_status_overwrite():
             raise PlynthError(
                 f"Target {self.gql.base.display_target} does not expose "
@@ -125,6 +122,11 @@ class PhaseOrchestrator:
                 f"cannot be configured. GHES 3.19+ is required. Remove the "
                 f"template's `status:` block to fall back to GitHub's defaults."
             )
+
+        # 1a. Resolve org and repo IDs
+        org_id = self.gql.get_org_id(self.plan.instance_org)
+        repo_id = self._resolve_repo_id()
+        self.state.repo = RepoState(name=self.plan.instance_repo, node_id=repo_id)
 
         # 1b. Create the project
         project = self.gql.create_project(org_id, self.plan.project_name)
@@ -199,12 +201,15 @@ class PhaseOrchestrator:
 
             self.state.fields[field_def.id] = FieldState(node_id=raw["id"], options=options_map)
 
-    def _resolve_default_status_value(self) -> str | None:
+    def _resolve_default_status_value(self) -> str:
         """Pick the Status option to apply to new items.
 
         Precedence: explicit ``default: true`` in template.status, then the
         first option in display order, then the GitHub default ``Backlog``
-        when the template doesn't configure status at all.
+        when the template doesn't configure status at all. Always returns
+        a value — the option may not exist on the project (caller does the
+        ``options.get(...)`` lookup), but the desired value itself is
+        always known.
         """
         if not self.plan.status_options:
             return "Backlog"
@@ -301,8 +306,7 @@ class PhaseOrchestrator:
             # behavior).
             if "_status" in self.state.fields:
                 status_field = self.state.fields["_status"]
-                default_value = self._resolve_default_status_value()
-                option_id = status_field.options.get(default_value) if default_value else None
+                option_id = status_field.options.get(self._resolve_default_status_value())
                 if option_id:
                     self.gql.set_field_value(
                         project_id=self.state.project.node_id,

--- a/plynth/engine/phases.py
+++ b/plynth/engine/phases.py
@@ -114,6 +114,18 @@ class PhaseOrchestrator:
         repo_id = self._resolve_repo_id()
         self.state.repo = RepoState(name=self.plan.instance_repo, node_id=repo_id)
 
+        # If the template configures custom Status options, gate on the
+        # GraphQL surface being present *before* creating anything. A 3.18
+        # instance would otherwise leave an orphan project behind when the
+        # mutation 422s mid-phase.
+        if self.plan.status_options and not self.gql.supports_status_overwrite():
+            raise PlynthError(
+                f"Target {self.gql.base.display_target} does not expose "
+                f"updateProjectV2Field.singleSelectOptions, so Status options "
+                f"cannot be configured. GHES 3.19+ is required. Remove the "
+                f"template's `status:` block to fall back to GitHub's defaults."
+            )
+
         # 1b. Create the project
         project = self.gql.create_project(org_id, self.plan.project_name)
         self.state.project = ProjectState(
@@ -141,6 +153,29 @@ class PhaseOrchestrator:
         # 1d. Re-query to get actual field IDs and option IDs
         raw_fields = self.gql.get_project_fields(self.state.project.node_id)
 
+        # 1e. Overwrite the system Status field's options if configured. Done
+        # before any items exist on the project, so the replace-the-list
+        # semantics of updateProjectV2Field cannot corrupt anything. The
+        # mutation response carries the new option IDs in the same order we
+        # sent — patch them straight back into `raw_fields` so the loop below
+        # treats Status uniformly with custom fields.
+        if self.plan.status_options:
+            status_raw = next((r for r in raw_fields if r.get("name") == "Status"), None)
+            if status_raw is None:
+                raise PlynthError(
+                    "Status field not present on freshly-created project. "
+                    "This is unexpected — open an issue with the project URL."
+                )
+            new_options = self.gql.update_field_options(
+                status_raw["id"],
+                [
+                    {"name": opt.value, "color": opt.color, "description": opt.description}
+                    for opt in self.plan.status_options
+                ],
+            )
+            status_raw["options"] = new_options
+            self.log.info(f"Configured Status field with {len(new_options)} custom options")
+
         for raw in raw_fields:
             matching = [f for f in self.plan.fields if f.name == raw.get("name")]
             if not matching:
@@ -163,6 +198,20 @@ class PhaseOrchestrator:
                     options_map[opt["name"]] = opt["id"]
 
             self.state.fields[field_def.id] = FieldState(node_id=raw["id"], options=options_map)
+
+    def _resolve_default_status_value(self) -> str | None:
+        """Pick the Status option to apply to new items.
+
+        Precedence: explicit ``default: true`` in template.status, then the
+        first option in display order, then the GitHub default ``Backlog``
+        when the template doesn't configure status at all.
+        """
+        if not self.plan.status_options:
+            return "Backlog"
+        for opt in self.plan.status_options:
+            if opt.default:
+                return opt.value
+        return self.plan.status_options[0].value
 
     def _resolve_repo_id(self) -> str:
         """Look up the repo node ID, creating the repo first if configured.
@@ -247,16 +296,19 @@ class PhaseOrchestrator:
             )
             issue_state.item_id = item_id
 
-            # 4b. Set Status to "Backlog"
+            # 4b. Set Status to the configured default (or "Backlog" if the
+            # template doesn't configure status, matching the pre-#14
+            # behavior).
             if "_status" in self.state.fields:
                 status_field = self.state.fields["_status"]
-                backlog_option_id = status_field.options.get("Backlog")
-                if backlog_option_id:
+                default_value = self._resolve_default_status_value()
+                option_id = status_field.options.get(default_value) if default_value else None
+                if option_id:
                     self.gql.set_field_value(
                         project_id=self.state.project.node_id,
                         item_id=item_id,
                         field_id=status_field.node_id,
-                        value={"singleSelectOptionId": backlog_option_id},
+                        value={"singleSelectOptionId": option_id},
                     )
 
             # 4c. Set custom field values

--- a/plynth/engine/planner.py
+++ b/plynth/engine/planner.py
@@ -14,7 +14,7 @@ from plynth.models.plan import (
     ResolvedIssue,
     ResolvedMilestone,
 )
-from plynth.models.template import TemplateDefinition
+from plynth.models.template import FieldOption, TemplateDefinition
 
 # Stable schema version for the JSON dry-run payload. Bump on
 # breaking shape changes; document in docs/dry-run-json.md.
@@ -166,19 +166,32 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
     # ── Step 6: Resolve field options ──────────────────────────────
     # Color is validated against OptionColor at template parse time, so any
     # color reaching here is already legal. None means "operator left it off"
-    # which we materialize as GRAY for the GraphQL mutation.
-    resolved_field_defs: list[ResolvedField] = []
-    for f in template.fields:
-        opts = [
+    # which we materialize as GRAY for the GraphQL mutation. Status options
+    # use the same shape: planner-side they go through the same placeholder
+    # resolution, engine-side they feed the same ProjectV2SingleSelectField
+    # option list (via updateProjectV2Field on the system Status field).
+    def _resolve_options(options: list[FieldOption]) -> list[ResolvedFieldOption]:
+        return [
             ResolvedFieldOption(
                 value=resolve_placeholders(opt.value, values),
                 color=opt.color or "GRAY",
                 description=resolve_placeholders(opt.description, values),
                 default=opt.default,
             )
-            for opt in f.options
+            for opt in options
         ]
-        resolved_field_defs.append(ResolvedField(id=f.id, name=f.name, type=f.type, options=opts))
+
+    resolved_status = _resolve_options(template.status)
+    if resolved_status and not any(opt.default for opt in resolved_status):
+        warnings.append(
+            f"status: no option marked default: true; "
+            f"new items will receive '{resolved_status[0].value}' (the first option)"
+        )
+
+    resolved_field_defs: list[ResolvedField] = [
+        ResolvedField(id=f.id, name=f.name, type=f.type, options=_resolve_options(f.options))
+        for f in template.fields
+    ]
 
     # ── Step 7: Enforce allow_unknown_values guard ─────────────────
     # For single-select fields where allow_unknown_values is false (the
@@ -216,7 +229,7 @@ def plan(template: TemplateDefinition, instance: InstanceConfig) -> ExecutionPla
         target=instance.target,
         project_name=instance.project.name,
         project_description=project_desc,
-        status_options=list(template.status),
+        status_options=resolved_status,
         fields=resolved_field_defs,
         milestones=resolved_milestones,
         issues=resolved_issues,
@@ -281,6 +294,20 @@ def format_dry_run(ep: ExecutionPlan) -> str:
         bl_str = ", ".join(bl_parts) if bl_parts else "(none)"
         w(f"       blocked_by: {bb_str} | blocks: {bl_str}")
     w("")
+
+    # Status (only when configured; empty means "keep GitHub defaults")
+    if ep.status_options:
+        default_value = next((o.value for o in ep.status_options if o.default), None)
+        suffix = (
+            f", default: {default_value}"
+            if default_value
+            else f", default: {ep.status_options[0].value} (first option, no default declared)"
+        )
+        w(f"Status options ({len(ep.status_options)}{suffix}):")
+        for opt in ep.status_options:
+            mark = " *" if opt.default else ""
+            w(f"  {opt.value} [{opt.color}]{mark}")
+        w("")
 
     # Fields
     w(f"Fields ({len(ep.fields)}):")

--- a/plynth/models/__init__.py
+++ b/plynth/models/__init__.py
@@ -24,12 +24,12 @@ from plynth.models.state import (
 )
 from plynth.models.template import (
     FieldDefinition,
+    FieldOption,
     IssueDefinition,
     MilestoneDefinition,
     PlaceholderSpec,
     PruningConfig,
     PruningRule,
-    StatusOption,
     TemplateDefinition,
     TemplateMetadata,
     ViewDefinition,
@@ -42,7 +42,7 @@ __all__ = [
     "TemplateDefinition",
     "TemplateMetadata",
     "PlaceholderSpec",
-    "StatusOption",
+    "FieldOption",
     "FieldDefinition",
     "MilestoneDefinition",
     "IssueDefinition",

--- a/plynth/models/plan.py
+++ b/plynth/models/plan.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
-from plynth.models.template import OptionColor, StatusOption, ViewDefinition
+from plynth.models.template import OptionColor, ViewDefinition
 
 
 class ResolvedIssue(BaseModel):
@@ -69,8 +69,10 @@ class ExecutionPlan(BaseModel):
     project_name: str
     project_description: str
 
-    # Resolved resources
-    status_options: list[StatusOption]
+    # Resolved resources. Status options share ResolvedFieldOption with
+    # custom fields: they go through the same placeholder + color pre-flight,
+    # and the engine consumes the same shape when calling updateProjectV2Field.
+    status_options: list[ResolvedFieldOption]
     fields: list[ResolvedField]
     milestones: list[ResolvedMilestone]
     issues: list[ResolvedIssue]

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -28,20 +28,14 @@ class PlaceholderSpec(BaseModel):
     required: bool = True
 
 
-class StatusOption(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    value: str
-    color: Literal["GRAY", "BLUE", "YELLOW", "RED", "PURPLE", "GREEN"]
-
-
 class FieldOption(BaseModel):
     """Rich form of a single-select field option.
 
     Templates may declare options as plain strings (legacy) or as objects
     with color/description/default/aliases/deprecated. A field_validator on
     FieldDefinition.options normalizes strings to FieldOption(value=...) so
-    the engine sees one shape post-parse.
+    the engine sees one shape post-parse. The same shape powers the
+    template-level ``status:`` block (the project's built-in Status field).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -52,6 +46,26 @@ class FieldOption(BaseModel):
     default: bool = False
     aliases: list[Annotated[str, Field(max_length=100)]] = []
     deprecated: bool = False
+
+
+def _normalize_string_options(v: Any) -> Any:
+    """Coerce a list that may mix strings and dicts into a list of dicts.
+
+    Used by both ``FieldDefinition.options`` and ``TemplateDefinition.status``
+    so legacy string-only YAML keeps parsing while richer objects roundtrip.
+    """
+    if not isinstance(v, list):
+        return v
+    return [{"value": opt} if isinstance(opt, str) else opt for opt in v]
+
+
+def _check_at_most_one_default(options: list[FieldOption], context: str) -> None:
+    defaults = [opt.value for opt in options if opt.default]
+    if len(defaults) > 1:
+        raise ValueError(
+            f"{context}: at most one option may have default: true "
+            f"(found {len(defaults)}: {defaults})"
+        )
 
 
 class FieldDefinition(BaseModel):
@@ -66,19 +80,11 @@ class FieldDefinition(BaseModel):
     @field_validator("options", mode="before")
     @classmethod
     def _normalize_options(cls, v: Any) -> Any:
-        """Accept legacy string options or rich objects. Strings become FieldOption(value=...)."""
-        if not isinstance(v, list):
-            return v
-        return [{"value": opt} if isinstance(opt, str) else opt for opt in v]
+        return _normalize_string_options(v)
 
     @model_validator(mode="after")
     def _at_most_one_default(self) -> FieldDefinition:
-        defaults = [opt.value for opt in self.options if opt.default]
-        if len(defaults) > 1:
-            raise ValueError(
-                f"Field '{self.id}': at most one option may have default: true "
-                f"(found {len(defaults)}: {defaults})"
-            )
+        _check_at_most_one_default(self.options, f"Field '{self.id}'")
         return self
 
 
@@ -182,7 +188,7 @@ class TemplateDefinition(BaseModel):
     schema_version: str
     template: TemplateMetadata
     placeholders: dict[str, PlaceholderSpec] = {}
-    status: list[StatusOption] = []
+    status: list[FieldOption] = []
     fields: list[FieldDefinition] = []
     milestones: list[MilestoneDefinition] = []
     issues: list[IssueDefinition] = []
@@ -190,6 +196,16 @@ class TemplateDefinition(BaseModel):
     pruning: PruningConfig | None = None
     defaults: TemplateDefaults = Field(default_factory=TemplateDefaults)
     reconciliation: ReconciliationConfig = Field(default_factory=ReconciliationConfig)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _normalize_status(cls, v: Any) -> Any:
+        return _normalize_string_options(v)
+
+    @model_validator(mode="after")
+    def _status_at_most_one_default(self) -> TemplateDefinition:
+        _check_at_most_one_default(self.status, "status")
+        return self
 
     @model_validator(mode="after")
     def _validate_references(self) -> TemplateDefinition:

--- a/plynth/queries/mutations.py
+++ b/plynth/queries/mutations.py
@@ -30,6 +30,25 @@ mutation CreateField($projectId: ID!, $name: String!, $dataType: ProjectV2Custom
 }
 """
 
+# Overwrites the option list on an existing single-select field. Same
+# replace-the-list semantics as createProjectV2Field — see the CRITICAL
+# block above ``GraphQLClient.update_field_options``. Available on cloud
+# (since 2024-12-12) and GHES 3.19+; older instances 422 on the input
+# argument, which is why ``introspect_update_field_input`` runs first.
+UPDATE_FIELD_OPTIONS = """
+mutation UpdateFieldOptions($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  updateProjectV2Field(input: {fieldId: $fieldId, singleSelectOptions: $options}) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+        options { id name color }
+      }
+    }
+  }
+}
+"""
+
 CREATE_ISSUE = """
 mutation CreateIssue($repositoryId: ID!, $title: String!, $body: String!, $milestoneId: ID) {
   createIssue(input: {repositoryId: $repositoryId, title: $title, body: $body, milestoneId: $milestoneId}) {

--- a/plynth/queries/queries.py
+++ b/plynth/queries/queries.py
@@ -16,6 +16,18 @@ query GetRepoId($owner: String!, $name: String!) {
 }
 """
 
+# Probes whether the GHES build supports configurable Status options
+# (i.e. ``UpdateProjectV2FieldInput`` carries ``singleSelectOptions``).
+# Cheaper and more durable than parsing the GHES version: a 3.19 patch
+# release that regressed the input field would still fail this introspection.
+INTROSPECT_UPDATE_FIELD_INPUT = """
+query IntrospectUpdateFieldInput {
+  __type(name: "UpdateProjectV2FieldInput") {
+    inputFields { name }
+  }
+}
+"""
+
 GET_PROJECT_FIELDS = """
 query GetProjectFields($projectId: ID!) {
   node(id: $projectId) {

--- a/tests/fixtures/minimal-template.yaml
+++ b/tests/fixtures/minimal-template.yaml
@@ -20,7 +20,7 @@ placeholders:
     required: false
 
 status:
-  - {value: "Todo", color: "GRAY"}
+  - {value: "Todo", color: "GRAY", default: true}
   - {value: "Done", color: "GREEN"}
 
 fields:

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -144,6 +144,123 @@ def test_graphql_error_response_raises() -> None:
         _client().get_org_id("nope")
 
 
+# ── #14: configurable Status field ────────────────────────────────
+
+
+@responses.activate
+def test_supports_status_overwrite_true_when_input_field_present() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "__type": {
+                    "inputFields": [
+                        {"name": "fieldId"},
+                        {"name": "name"},
+                        {"name": "singleSelectOptions"},
+                        {"name": "iterationConfiguration"},
+                    ]
+                }
+            }
+        },
+        status=200,
+    )
+    assert _client().supports_status_overwrite() is True
+
+
+@responses.activate
+def test_supports_status_overwrite_false_on_pre_3_19_instance() -> None:
+    # Older instances expose UpdateProjectV2FieldInput without singleSelectOptions
+    # (or even with __type returning null if the input doesn't exist at all).
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"__type": {"inputFields": [{"name": "fieldId"}, {"name": "name"}]}}},
+        status=200,
+    )
+    assert _client().supports_status_overwrite() is False
+
+
+@responses.activate
+def test_supports_status_overwrite_false_when_type_missing() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"data": {"__type": None}},
+        status=200,
+    )
+    assert _client().supports_status_overwrite() is False
+
+
+@responses.activate
+def test_update_field_options_returns_server_options() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "updateProjectV2Field": {
+                    "projectV2Field": {
+                        "id": "PVTSSF_1",
+                        "name": "Status",
+                        "options": [
+                            {"id": "abc", "name": "Triaged", "color": "GRAY"},
+                            {"id": "def", "name": "Done", "color": "GREEN"},
+                        ],
+                    }
+                }
+            }
+        },
+        status=200,
+    )
+    out = _client().update_field_options(
+        "PVTSSF_1",
+        [
+            {"name": "Triaged", "color": "GRAY", "description": ""},
+            {"name": "Done", "color": "GREEN", "description": ""},
+        ],
+    )
+    assert [o["name"] for o in out] == ["Triaged", "Done"]
+    # Server-issued option IDs round-trip back so the caller can wire them
+    # into project state without a follow-up re-query.
+    assert out[0]["id"] == "abc"
+
+
+@responses.activate
+def test_update_field_options_sends_options_in_input_order() -> None:
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={
+            "data": {
+                "updateProjectV2Field": {
+                    "projectV2Field": {"id": "PVTSSF_1", "name": "Status", "options": []}
+                }
+            }
+        },
+        status=200,
+    )
+    requested = [
+        {"name": "Triaged", "color": "GRAY", "description": ""},
+        {"name": "Spec'd", "color": "BLUE", "description": ""},
+        {"name": "Done", "color": "GREEN", "description": ""},
+    ]
+    _client().update_field_options("PVTSSF_1", requested)
+
+    sent = responses.calls[0].request
+    body_text = sent.body.decode() if isinstance(sent.body, bytes) else sent.body
+    payload = json.loads(body_text)
+    # Plynth's promise of "order matches template" depends on the request
+    # body preserving order — pin it so a future refactor that hands options
+    # off to a set/dict-keyed structure trips this test.
+    assert [o["name"] for o in payload["variables"]["options"]] == [
+        "Triaged",
+        "Spec'd",
+        "Done",
+    ]
+
+
 @responses.activate
 def test_request_body_includes_query_and_variables() -> None:
     responses.add(

--- a/tests/test_models_template.py
+++ b/tests/test_models_template.py
@@ -63,9 +63,21 @@ def test_extra_keys_rejected() -> None:
 
 def test_invalid_status_color_rejected() -> None:
     data = _base_template_dict()
-    data["status"][0]["color"] = "ORANGE"
+    data["status"][0]["color"] = "TEAL"
     with pytest.raises(ValidationError):
         TemplateDefinition.model_validate(data)
+
+
+def test_status_accepts_full_option_color_set() -> None:
+    """status: now uses FieldOption, so ORANGE and PINK are valid (not just
+    the six-color subset the dropped StatusOption model allowed)."""
+    data = _base_template_dict()
+    data["status"] = [
+        {"value": "Triaged", "color": "ORANGE"},
+        {"value": "Done", "color": "PINK"},
+    ]
+    t = TemplateDefinition.model_validate(data)
+    assert [o.color for o in t.status] == ["ORANGE", "PINK"]
 
 
 def test_pruning_unknown_trigger_rejected() -> None:
@@ -194,6 +206,50 @@ def test_template_defaults_unknown_field_key_rejected() -> None:
     data["defaults"] = {"fields": {"nope": "x"}}
     with pytest.raises(ValidationError, match="defaults.fields: key 'nope' not found"):
         TemplateDefinition.model_validate(data)
+
+
+# ── #14: configurable Status field ─────────────────────────────────
+
+
+def test_status_legacy_string_form_normalizes() -> None:
+    data = _base_template_dict()
+    data["status"] = ["Triaged", "Done"]
+    t = TemplateDefinition.model_validate(data)
+    assert [o.value for o in t.status] == ["Triaged", "Done"]
+    assert all(o.color is None for o in t.status)
+    assert all(o.default is False for o in t.status)
+
+
+def test_status_rich_form_roundtrips() -> None:
+    data = _base_template_dict()
+    data["status"] = [
+        {"value": "Triaged", "color": "GRAY", "default": True},
+        {"value": "Spec'd", "color": "BLUE", "description": "Acceptance written"},
+        "Done",  # mixing legacy strings allowed
+    ]
+    t = TemplateDefinition.model_validate(data)
+    assert [o.value for o in t.status] == ["Triaged", "Spec'd", "Done"]
+    assert t.status[0].default is True
+    assert t.status[1].description == "Acceptance written"
+    assert t.status[2].color is None
+
+
+def test_status_two_defaults_rejected() -> None:
+    data = _base_template_dict()
+    data["status"] = [
+        {"value": "Triaged", "default": True},
+        {"value": "Done", "default": True},
+    ]
+    with pytest.raises(ValidationError, match="at most one option may have default"):
+        TemplateDefinition.model_validate(data)
+
+
+def test_status_empty_list_is_valid() -> None:
+    """No status block (or empty) means 'keep GitHub defaults' — supported."""
+    data = _base_template_dict()
+    data["status"] = []
+    t = TemplateDefinition.model_validate(data)
+    assert t.status == []
 
 
 # ── M1-G: reconciliation namespace stub ────────────────────────────

--- a/tests/test_phases_e2e.py
+++ b/tests/test_phases_e2e.py
@@ -49,11 +49,74 @@ class _GraphQLDispatcher:
         self.created_issue_node_ids: list[str] = []
         self.body_updates: list[tuple[str, str]] = []
         self.add_blocked_by_calls: list[tuple[str, str]] = []
+        self.update_field_options_calls: list[tuple[str, list[dict]]] = []
+        self.set_field_value_calls: list[dict] = []
+        # Tracks Status options the dispatcher should pretend live on the
+        # project. Mutated by updateProjectV2Field so a follow-up
+        # get_project_fields would see the new list (today the engine reads
+        # the mutation response directly, so this is belt-and-braces).
+        self.status_options: list[dict] = [
+            {"id": "opt_backlog", "name": "Backlog"},
+            {"id": "opt_done", "name": "Done"},
+        ]
 
     def __call__(self, request) -> tuple[int, dict, str]:  # type: ignore[no-untyped-def]
         payload = json.loads(request.body)
         query = payload["query"]
         variables = payload.get("variables", {})
+
+        if "__type(name:" in query and "UpdateProjectV2FieldInput" in query:
+            # GHES 3.19+ exposes singleSelectOptions on UpdateProjectV2FieldInput.
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "__type": {
+                                "inputFields": [
+                                    {"name": "clientMutationId"},
+                                    {"name": "fieldId"},
+                                    {"name": "iterationConfiguration"},
+                                    {"name": "name"},
+                                    {"name": "singleSelectOptions"},
+                                ]
+                            }
+                        }
+                    }
+                ),
+            )
+
+        if "updateProjectV2Field(" in query:
+            self.update_field_options_calls.append((variables["fieldId"], variables["options"]))
+            # Server overwrites the option list and assigns fresh IDs in the
+            # order received. Plynth captures these directly from the response.
+            new_opts = [
+                {
+                    "id": f"opt_{opt['name'].lower().replace(' ', '_').replace(chr(39), '')}",
+                    "name": opt["name"],
+                    "color": opt.get("color", "GRAY"),
+                }
+                for opt in variables["options"]
+            ]
+            self.status_options = new_opts
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "data": {
+                            "updateProjectV2Field": {
+                                "projectV2Field": {
+                                    "id": variables["fieldId"],
+                                    "name": "Status",
+                                    "options": new_opts,
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
 
         if "GET_ORG_ID" in query or "organization(login" in query:
             return (200, {}, json.dumps({"data": {"organization": {"id": "O_1"}}}))
@@ -99,7 +162,10 @@ class _GraphQLDispatcher:
             )
 
         if "node(id:" in query and "ProjectV2" in query:
-            # get_project_fields — return Status (built-in) plus our custom fields.
+            # get_project_fields — return Status (built-in) with whatever the
+            # current overwrite state says, plus our custom fields. Phase 1d
+            # reads this *before* updateProjectV2Field, so on the first call
+            # status_options still carries the GH defaults.
             return (
                 200,
                 {},
@@ -112,10 +178,7 @@ class _GraphQLDispatcher:
                                         {
                                             "id": "PVTSSF_status",
                                             "name": "Status",
-                                            "options": [
-                                                {"id": "opt_backlog", "name": "Backlog"},
-                                                {"id": "opt_done", "name": "Done"},
-                                            ],
+                                            "options": list(self.status_options),
                                         },
                                         {
                                             "id": "PVTSSF_Priority",
@@ -167,6 +230,7 @@ class _GraphQLDispatcher:
             )
 
         if "updateProjectV2ItemFieldValue(" in query:
+            self.set_field_value_calls.append(variables)
             return (
                 200,
                 {},
@@ -249,10 +313,22 @@ def test_phases_e2e_happy_path(
     assert state.project.number == 7
     assert state.repo is not None
     assert state.repo.node_id == "R_1"
-    # Status field captured under the synthetic "_status" key
+    # Status field captured under the synthetic "_status" key. The fixture's
+    # status block (Todo + Done, Todo default) overwrote GH's defaults, so the
+    # state reflects the post-overwrite shape with server-issued option IDs.
     assert "_status" in state.fields
-    assert state.fields["_status"].options["Backlog"] == "opt_backlog"
+    assert set(state.fields["_status"].options.keys()) == {"Todo", "Done"}
+    assert state.fields["_status"].options["Todo"] == "opt_todo"
+    # The overwrite mutation ran exactly once and sent options in declaration order.
+    assert len(dispatcher.update_field_options_calls) == 1
+    sent_options = dispatcher.update_field_options_calls[0][1]
+    assert [o["name"] for o in sent_options] == ["Todo", "Done"]
     assert "priority" in state.fields
+    # Phase 4b set every item to the configured default ("Todo"), not the old
+    # hard-coded "Backlog".
+    status_writes = [c for c in dispatcher.set_field_value_calls if c["fieldId"] == "PVTSSF_status"]
+    assert len(status_writes) == len(state.issues)
+    assert all(c["value"]["singleSelectOptionId"] == "opt_todo" for c in status_writes)
 
     # Phase 2 — milestones via REST
     assert state.is_phase_complete(PHASE_2_MILESTONES)
@@ -309,7 +385,7 @@ def test_phases_e2e_happy_path(
     assert set(on_disk.issues.keys()) == {"001", "002", "003"}
     assert {iss.number for iss in on_disk.issues.values()} == {47, 48, 49}
     assert "_status" in on_disk.fields
-    assert on_disk.fields["_status"].options["Backlog"] == "opt_backlog"
+    assert on_disk.fields["_status"].options["Todo"] == "opt_todo"
     on_disk_edges = {(e.blocked, e.blocker) for e in on_disk.dependencies_created}
     assert on_disk_edges == {("002", "001"), ("003", "002")}
     for phase in (

--- a/tests/test_phases_status.py
+++ b/tests/test_phases_status.py
@@ -88,11 +88,12 @@ def _make_orchestrator(
     return orch, state
 
 
-def test_phase_1_aborts_before_creating_project_when_overwrite_unsupported(
+def test_phase_1_probe_runs_before_any_side_effects_when_unsupported(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:
-    """A 3.18 instance must fail loud at the start of Phase 1 — no project
-    or fields should be created."""
+    """A 3.18 instance must fail before _resolve_repo_id() runs — otherwise
+    `repo.create: true` would create a repo we'd immediately abandon when
+    the probe failed (orphan-repo bug Copilot caught on PR #57)."""
     plan = _make_plan(
         status_options=[
             ResolvedFieldOption(value="Todo", color="GRAY", default=True),
@@ -106,6 +107,11 @@ def test_phase_1_aborts_before_creating_project_when_overwrite_unsupported(
     with pytest.raises(PlynthError, match="GHES 3.19"):
         orch.phase_1_create_project_and_fields()
 
+    # Probe gates on schema only; nothing touching the org/repo/project
+    # surface should have run.
+    orch.gql.get_org_id.assert_not_called()
+    orch.gql.get_repo_id.assert_not_called()
+    orch.rest.create_repo.assert_not_called()
     orch.gql.create_project.assert_not_called()
     orch.gql.create_field.assert_not_called()
     orch.gql.update_field_options.assert_not_called()

--- a/tests/test_phases_status.py
+++ b/tests/test_phases_status.py
@@ -1,0 +1,216 @@
+"""Phase-level tests for the configurable Status field (#14).
+
+Covers the three behaviors that don't need the full e2e dispatcher:
+
+* Status overwrite is gated on the introspection probe — a 3.18 instance
+  must fail before any project is created (no orphan projects).
+* An empty ``plan.status_options`` skips both the probe and the mutation
+  and keeps the pre-#14 ``Backlog`` default.
+* Phase 4b reads the configured default rather than the old hard-coded
+  ``Backlog`` string.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from plynth.engine.phases import PhaseOrchestrator
+from plynth.errors import PlynthError
+from plynth.models.plan import (
+    ExecutionPlan,
+    ResolvedField,
+    ResolvedFieldOption,
+    ResolvedIssue,
+    ResolvedMilestone,
+)
+from plynth.models.state import StateFile
+
+
+def _make_plan(
+    *,
+    status_options: list[ResolvedFieldOption] | None = None,
+    issues: list[ResolvedIssue] | None = None,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        template_name="t",
+        template_version="0.0.1",
+        instance_org="example-org",
+        instance_repo="acme",
+        target="https://ghes.example.com",
+        project_name="Acme",
+        project_description="",
+        status_options=status_options or [],
+        fields=[ResolvedField(id="priority", name="Priority", type="single_select", options=[])],
+        milestones=[ResolvedMilestone(id="M1", title="M1", description="", due_date=None)],
+        issues=issues
+        or [
+            ResolvedIssue(
+                template_id="001",
+                title="i1",
+                body="b",
+                milestone_id="M1",
+                fields={},
+                blocked_by=[],
+                blocks=[],
+                skipped_blocked_by=[],
+                skipped_blocks=[],
+            )
+        ],
+        views=[],
+        placeholder_values={},
+        skipped_milestones=[],
+        skipped_issues=[],
+        warnings=[],
+    )
+
+
+def _make_orchestrator(
+    mocker: MockerFixture,
+    plan: ExecutionPlan,
+    state_path: Path,
+) -> tuple[PhaseOrchestrator, StateFile]:
+    state = StateFile(target=plan.target, org=plan.instance_org)
+    gql = mocker.MagicMock()
+    gql.base.display_target = "ghes.example.com"
+    rest = mocker.MagicMock()
+    orch = PhaseOrchestrator(
+        plan=plan,
+        gql=gql,
+        rest=rest,
+        state=state,
+        state_path=state_path,
+        logger=logging.getLogger("plynth.test"),
+    )
+    return orch, state
+
+
+def test_phase_1_aborts_before_creating_project_when_overwrite_unsupported(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """A 3.18 instance must fail loud at the start of Phase 1 — no project
+    or fields should be created."""
+    plan = _make_plan(
+        status_options=[
+            ResolvedFieldOption(value="Todo", color="GRAY", default=True),
+        ]
+    )
+    orch, _ = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    orch.gql.supports_status_overwrite.return_value = False
+    orch.gql.get_org_id.return_value = "O_1"
+    orch.gql.get_repo_id.return_value = "R_1"
+
+    with pytest.raises(PlynthError, match="GHES 3.19"):
+        orch.phase_1_create_project_and_fields()
+
+    orch.gql.create_project.assert_not_called()
+    orch.gql.create_field.assert_not_called()
+    orch.gql.update_field_options.assert_not_called()
+
+
+def test_phase_1_skips_probe_and_mutation_when_status_unconfigured(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """No status block means no probe and no mutation — backward-compatible
+    with templates written before #14."""
+    plan = _make_plan(status_options=[])
+    orch, state = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    orch.gql.get_org_id.return_value = "O_1"
+    orch.gql.get_repo_id.return_value = "R_1"
+    orch.gql.create_project.return_value = {
+        "id": "PVT_1",
+        "url": "https://x",
+        "number": 1,
+    }
+    orch.gql.get_project_fields.return_value = [
+        {
+            "id": "PVTSSF_status",
+            "name": "Status",
+            "options": [{"id": "opt_backlog", "name": "Backlog"}],
+        },
+    ]
+
+    orch.phase_1_create_project_and_fields()
+
+    orch.gql.supports_status_overwrite.assert_not_called()
+    orch.gql.update_field_options.assert_not_called()
+    assert state.fields["_status"].options == {"Backlog": "opt_backlog"}
+
+
+def test_phase_1_overwrites_status_options_when_configured(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    plan = _make_plan(
+        status_options=[
+            ResolvedFieldOption(value="Triaged", color="GRAY", default=True),
+            ResolvedFieldOption(value="Done", color="GREEN"),
+        ]
+    )
+    orch, state = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    orch.gql.supports_status_overwrite.return_value = True
+    orch.gql.get_org_id.return_value = "O_1"
+    orch.gql.get_repo_id.return_value = "R_1"
+    orch.gql.create_project.return_value = {
+        "id": "PVT_1",
+        "url": "https://x",
+        "number": 1,
+    }
+    orch.gql.get_project_fields.return_value = [
+        {
+            "id": "PVTSSF_status",
+            "name": "Status",
+            "options": [{"id": "opt_backlog", "name": "Backlog"}],
+        },
+    ]
+    orch.gql.update_field_options.return_value = [
+        {"id": "opt_triaged", "name": "Triaged", "color": "GRAY"},
+        {"id": "opt_done", "name": "Done", "color": "GREEN"},
+    ]
+
+    orch.phase_1_create_project_and_fields()
+
+    orch.gql.update_field_options.assert_called_once()
+    field_id, sent_options = orch.gql.update_field_options.call_args.args
+    assert field_id == "PVTSSF_status"
+    assert [o["name"] for o in sent_options] == ["Triaged", "Done"]
+    assert state.fields["_status"].options == {
+        "Triaged": "opt_triaged",
+        "Done": "opt_done",
+    }
+
+
+def test_resolve_default_status_value_picks_explicit_default(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    plan = _make_plan(
+        status_options=[
+            ResolvedFieldOption(value="Triaged", color="GRAY"),
+            ResolvedFieldOption(value="Done", color="GREEN", default=True),
+        ]
+    )
+    orch, _ = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    assert orch._resolve_default_status_value() == "Done"
+
+
+def test_resolve_default_status_value_falls_back_to_first_option(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    plan = _make_plan(
+        status_options=[
+            ResolvedFieldOption(value="Triaged", color="GRAY"),
+            ResolvedFieldOption(value="Done", color="GREEN"),
+        ]
+    )
+    orch, _ = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    assert orch._resolve_default_status_value() == "Triaged"
+
+
+def test_resolve_default_status_value_keeps_backlog_when_unconfigured(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    plan = _make_plan(status_options=[])
+    orch, _ = _make_orchestrator(mocker, plan, tmp_path / "state.yaml")
+    assert orch._resolve_default_status_value() == "Backlog"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -247,6 +247,56 @@ def test_plan_unknown_value_via_instance_override_rejected(
         plan(minimal_template, minimal_instance)
 
 
+# ── #14: configurable Status field ────────────────────────────────
+
+
+def test_plan_status_options_carry_through_with_color_and_default(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    # Fixture: Todo (default), Done.
+    assert [o.value for o in ep.status_options] == ["Todo", "Done"]
+    assert ep.status_options[0].default is True
+    assert ep.status_options[0].color == "GRAY"
+    assert ep.status_options[1].default is False
+    # Status options share ResolvedFieldOption with custom fields.
+    from plynth.models.plan import ResolvedFieldOption
+
+    assert all(isinstance(o, ResolvedFieldOption) for o in ep.status_options)
+
+
+def test_plan_status_resolves_placeholders(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.status[0].value = "{TEAM} Triaged"
+    ep = plan(minimal_template, minimal_instance)
+    assert ep.status_options[0].value == "Platform Triaged"
+
+
+def test_plan_status_no_default_emits_warning(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    for opt in minimal_template.status:
+        opt.default = False
+    ep = plan(minimal_template, minimal_instance)
+    assert any("no option marked default" in w for w in ep.warnings)
+
+
+def test_plan_status_with_default_no_warning(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    ep = plan(minimal_template, minimal_instance)
+    assert not any("default: true" in w for w in ep.warnings)
+
+
+def test_plan_empty_status_means_keep_github_defaults(
+    minimal_template: TemplateDefinition, minimal_instance: InstanceConfig
+) -> None:
+    minimal_template.status = []
+    ep = plan(minimal_template, minimal_instance)
+    assert ep.status_options == []
+
+
 # ── M2: JSON dry-run output ───────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #14. Last of the four bootstrap-loop items in the v0.4.0 milestone.

The template-level `status:` block, previously parsed but inert, now drives the project's built-in Status field via `updateProjectV2Field`. Phase 1 overwrites GitHub's defaults with the declared options in input order; Phase 4b reads `default: true` to pick what new items receive, replacing the hard-coded `Backlog` lookup.

## What's in

- **Status block now functional.** Folds the dead `StatusOption` model into `FieldOption` (rich shape from #42) and wires it through the planner + engine. Existing templates without a `status:` block keep GitHub's defaults exactly as before.
- **`update_field_options` mutation** on `GraphQLClient` wrapping `updateProjectV2Field`. Same replace-the-list semantics as `create_field`; CRITICAL comment block applies. Slots between the post-create field re-query and the options-map build, so the existing loop handles Status uniformly.
- **`supports_status_overwrite()` introspection probe.** Runs at the very start of Phase 1 if `status:` is configured. A 3.18 instance fails with a clear "GHES 3.19+ required" error before any project is created, so there are no orphan projects on older instances. Same family as the #15 GHES version probe but more durable: catches a 3.19 patch that ever regressed the input field.
- **`default: true` on the status block** picks what Phase 4b applies to new items. Precedence: explicit default → first option (with planner warning) → `Backlog` fallback when `status:` is absent.

## Out of scope

- Reconciliation against an existing project's Status options (M5 / `verify_after_apply`).
- Per-issue status assignment in the template (M2 alongside labels and issue types).
- The 401 error message's classic-PAT-only guidance — that's #40, and the wording there should be updated to also cover the FGPAT path now that configurable Status leans on the same auth surface.

## Verification

- `pytest -q` — 234 passed, 2 POSIX skips. New tests: 12 covering the model normalization, planner plumbing, GraphQL client probe + mutation (request-body order pinned), and Phase 1/4b behavior under both configured and absent `status:` blocks. The e2e dispatcher gained branches for the introspection probe and the overwrite mutation; the happy path now asserts the mutation ran exactly once with options in declaration order, and Phase 4b applied the configured default to every item.
- `ruff check`, `ruff format --check`, `mypy plynth` all green.

Confidence on the runtime behavior: high. The introspection probe was verified against a 3.19.4 GHES instance, and the public `updateProjectV2Field` mutation was verified end-to-end with a fine-grained PAT against the system Status field on the same instance — including option-order preservation through the GraphQL path (the in-UI Projects settings flow re-sequences, but the API path does not).