### PR TITLE
fix(engine): align 401 wording with SECURITY.md (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **401 error wording** (#40). Both the GraphQL and REST 401 handlers
+  now point at SECURITY.md and name both PAT shapes (classic `repo` +
+  `project`, or fine-grained Issues + Projects). Pre-#40 they only
+  mentioned the classic-PAT scopes, which contradicted the documented
+  fine-grained path. Wording centralized in
+  `plynth.errors.token_rejected_message()` so the runtime can't drift
+  away from SECURITY.md again. The repo-create 401 (only fires under
+  `repo.create: true`) keeps its operation-specific Administration
+  guidance unchanged.
 - **SECURITY.md** now documents the exact PAT permissions plynth needs.
   A fine-grained PAT with repository *Issues: Read and write* +
   organization *Projects: Read and write* is the recommended shape on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,10 +81,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - **401 error wording** (#40). Both the GraphQL and REST 401 handlers
-  now point at SECURITY.md and name both PAT shapes (classic `repo` +
-  `project`, or fine-grained Issues + Projects). Pre-#40 they only
-  mentioned the classic-PAT scopes, which contradicted the documented
-  fine-grained path. Wording centralized in
+  now point at SECURITY.md and name all three supported token shapes
+  (classic PAT, fine-grained PAT, GitHub App). Pre-#40 they only
+  mentioned classic-PAT scopes, which contradicted the documented
+  fine-grained and GitHub App paths. Wording centralized in
   `plynth.errors.token_rejected_message()` so the runtime can't drift
   away from SECURITY.md again. The repo-create 401 (only fires under
   `repo.create: true`) keeps its operation-specific Administration

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import requests
 
 from plynth.engine.api_base import GitHubClient
-from plynth.errors import AuthError, NetworkError, NotFoundError, PlynthError
+from plynth.errors import (
+    AuthError,
+    NetworkError,
+    NotFoundError,
+    PlynthError,
+    token_rejected_message,
+)
 from plynth.queries import mutations, queries
 
 
@@ -67,10 +73,7 @@ class GraphQLClient:
                 return result["data"]
 
             if response.status_code == 401:
-                raise AuthError(
-                    f"Token rejected by {self.base.display_target}; verify PLYNTH_TOKEN "
-                    f"scopes include `repo` and `project`."
-                )
+                raise AuthError(token_rejected_message(self.base.display_target))
 
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -5,7 +5,7 @@ import logging
 import requests
 
 from plynth.engine.api_base import GitHubClient
-from plynth.errors import AuthError, NetworkError, NotFoundError
+from plynth.errors import AuthError, NetworkError, NotFoundError, token_rejected_message
 
 
 class RESTClient:
@@ -110,10 +110,7 @@ class RESTClient:
                 }
 
             if response.status_code == 401:
-                raise AuthError(
-                    f"Token rejected by {self.base.display_target}; verify PLYNTH_TOKEN "
-                    f"scopes include `repo` and `project`."
-                )
+                raise AuthError(token_rejected_message(self.base.display_target))
             if response.status_code == 404:
                 raise NotFoundError(
                     f"Repository {owner}/{repo} not found on {self.base.display_target}"

--- a/plynth/errors.py
+++ b/plynth/errors.py
@@ -29,10 +29,26 @@ class ConfigError(PlynthError):
     """Local configuration problem: missing file, invalid YAML, schema error."""
 
 
+def token_rejected_message(display_target: str) -> str:
+    """Standard 401 advice for the GraphQL and REST clients.
+
+    Single source of truth for the wording so the runtime message can't
+    drift away from SECURITY.md. The two PAT shapes named here mirror the
+    SECURITY.md "Token shapes" section verbatim — adjust both at once.
+    """
+    return (
+        f"Token rejected by {display_target}; verify PLYNTH_TOKEN has either "
+        f"classic `repo` + `project` scopes or a fine-grained PAT with "
+        f"repository Issues (Read and write) plus organization Projects "
+        f"(Read and write). See SECURITY.md for the full permission breakdown."
+    )
+
+
 __all__ = [
     "PlynthError",
     "AuthError",
     "NotFoundError",
     "NetworkError",
     "ConfigError",
+    "token_rejected_message",
 ]

--- a/plynth/errors.py
+++ b/plynth/errors.py
@@ -33,14 +33,15 @@ def token_rejected_message(display_target: str) -> str:
     """Standard 401 advice for the GraphQL and REST clients.
 
     Single source of truth for the wording so the runtime message can't
-    drift away from SECURITY.md. The two PAT shapes named here mirror the
-    SECURITY.md "Token shapes" section verbatim — adjust both at once.
+    drift away from SECURITY.md. The three token shapes named here track
+    the subsections under SECURITY.md ``## Token handling`` (Fine-grained
+    PAT, Classic PAT, GitHub Apps) — keep this list in sync if a fourth
+    shape ever lands.
     """
     return (
-        f"Token rejected by {display_target}; verify PLYNTH_TOKEN has either "
-        f"classic `repo` + `project` scopes or a fine-grained PAT with "
-        f"repository Issues (Read and write) plus organization Projects "
-        f"(Read and write). See SECURITY.md for the full permission breakdown."
+        f"Token rejected by {display_target}; verify PLYNTH_TOKEN has scopes "
+        f"covering issue and project mutations. See SECURITY.md for supported "
+        f"token shapes (classic PAT, fine-grained PAT, GitHub App)."
     )
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -24,6 +24,20 @@ def _rest() -> RESTClient:
     return RESTClient(GitHubClient(GHES_URL, "tok", write_delay_ms=0))
 
 
+def _assert_token_rejected_wording(msg: str) -> None:
+    """Pin the wording produced by ``token_rejected_message`` (#40, PR #58 review).
+
+    All three SECURITY.md-supported token shapes must be named so a user
+    with any one of them sees themselves in the advice; ``SECURITY.md``
+    must be referenced so a future permission change can update one place.
+    """
+    assert "Token rejected" in msg
+    assert "classic PAT" in msg
+    assert "fine-grained PAT" in msg
+    assert "GitHub App" in msg
+    assert "SECURITY.md" in msg
+
+
 def test_error_hierarchy() -> None:
     # All friendly errors are PlynthError; GraphQLError is also PlynthError now.
     for exc_cls in (AuthError, NotFoundError, NetworkError, GraphQLError):
@@ -38,15 +52,7 @@ def test_graphql_401_raises_auth_error() -> None:
     responses.add(responses.POST, GRAPHQL_URL, status=401)
     with pytest.raises(AuthError) as excinfo:
         _gql().get_org_id("nope")
-    msg = str(excinfo.value)
-    # Both PAT shapes (#40): the message used to recommend only classic
-    # `repo` + `project`, which contradicted the FGPAT path documented in
-    # SECURITY.md. Now both shapes are named, with SECURITY.md as the
-    # canonical reference.
-    assert "Token rejected" in msg
-    assert "classic" in msg and "fine-grained" in msg
-    assert "Issues" in msg and "Projects" in msg
-    assert "SECURITY.md" in msg
+    _assert_token_rejected_wording(str(excinfo.value))
 
 
 @responses.activate
@@ -143,11 +149,9 @@ def test_rest_401_raises_auth_error() -> None:
     responses.add(responses.POST, MILESTONE_URL, status=401)
     with pytest.raises(AuthError) as excinfo:
         _rest().create_milestone(owner="example-org", repo="acme", title="T")
-    msg = str(excinfo.value)
-    # REST and GraphQL share the helper from #40; same wording assertions.
-    assert "Token rejected" in msg
-    assert "classic" in msg and "fine-grained" in msg
-    assert "SECURITY.md" in msg
+    # REST and GraphQL share the same helper, so they MUST produce the
+    # same wording — pin both with the shared assertion.
+    _assert_token_rejected_wording(str(excinfo.value))
 
 
 @responses.activate

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -36,8 +36,17 @@ def test_error_hierarchy() -> None:
 @responses.activate
 def test_graphql_401_raises_auth_error() -> None:
     responses.add(responses.POST, GRAPHQL_URL, status=401)
-    with pytest.raises(AuthError, match="Token rejected"):
+    with pytest.raises(AuthError) as excinfo:
         _gql().get_org_id("nope")
+    msg = str(excinfo.value)
+    # Both PAT shapes (#40): the message used to recommend only classic
+    # `repo` + `project`, which contradicted the FGPAT path documented in
+    # SECURITY.md. Now both shapes are named, with SECURITY.md as the
+    # canonical reference.
+    assert "Token rejected" in msg
+    assert "classic" in msg and "fine-grained" in msg
+    assert "Issues" in msg and "Projects" in msg
+    assert "SECURITY.md" in msg
 
 
 @responses.activate
@@ -132,8 +141,13 @@ def test_graphql_timeout_message_uses_configured_value() -> None:
 @responses.activate
 def test_rest_401_raises_auth_error() -> None:
     responses.add(responses.POST, MILESTONE_URL, status=401)
-    with pytest.raises(AuthError, match="Token rejected"):
+    with pytest.raises(AuthError) as excinfo:
         _rest().create_milestone(owner="example-org", repo="acme", title="T")
+    msg = str(excinfo.value)
+    # REST and GraphQL share the helper from #40; same wording assertions.
+    assert "Token rejected" in msg
+    assert "classic" in msg and "fine-grained" in msg
+    assert "SECURITY.md" in msg
 
 
 @responses.activate


### PR DESCRIPTION
Closes #40.

Pre-#40 the 401 handlers in [`graphql_client.py:71-72`](plynth/engine/graphql_client.py#L71-L72) and [`rest_client.py:114-115`](plynth/engine/rest_client.py#L114-L115) told users to verify their `PLYNTH_TOKEN` had classic \`repo\` + \`project\` scopes. SECURITY.md and the README have been recommending a fine-grained PAT (Issues R/W + Projects R/W) as the preferred shape since #39, so a user who followed the docs and hit a 401 got contradictory runtime advice.

## What's in

- **New helper** [`plynth.errors.token_rejected_message(display_target)`](plynth/errors.py) is the single source of truth for 401 wording. Names both PAT shapes (classic \`repo\` + \`project\`, fine-grained Issues + Projects R/W) and points at SECURITY.md as the canonical reference. Both clients call it.
- **GraphQL client** ([`graphql_client.py`](plynth/engine/graphql_client.py)) and **REST client** ([`rest_client.py`](plynth/engine/rest_client.py)) 401 handlers now use the helper. No behavior change beyond the message string.
- **CHANGELOG** entry under \`Changed\` for v0.4.0.
- **Tests** in [`test_errors.py`](tests/test_errors.py) tightened: previously matched only the literal "Token rejected" prefix, now assert both PAT shapes and \`SECURITY.md\` appear in the message. Pins the wording so a future drift fails the suite.

## Out of scope

The repo-create 401 ([`rest_client.py:165-170`](plynth/engine/rest_client.py#L165-L170)) keeps its operation-specific Administration guidance unchanged. That message is about the extra permission needed for the create-repo REST call (classic \`repo\` or fine-grained Administration R/W), not the general token-rejection case. #40 only names the first two sites.

## Verification

\`pytest -q\` 222 passed, 2 POSIX skips. \`ruff check\`, \`ruff format --check\`, \`mypy plynth\` all green.