### PR TITLE
ci: add ci-summary aggregate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,25 @@ jobs:
           ignore-vulns: |
             CVE-2026-3219
             CVE-2026-6357
+
+  # Single aggregate check that the org-level branch ruleset can require
+  # by name. `if: always()` is load-bearing: without it, a failed/skipped
+  # upstream job leaves this one "skipped", which counts as a pass on a
+  # required check. Explicit per-need result comparison rather than
+  # `contains(needs.*.result, 'failure')` so cancelled or skipped legs
+  # also fail the gate. See Declaratus/governance spec 01 risk #3 and
+  # RUNBOOKS/ruleset-rollout.md § Status checks.
+  ci-summary:
+    name: ci-summary
+    needs: [test, audit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded
+        run: |
+          test_result='${{ needs.test.result }}'
+          audit_result='${{ needs.audit.result }}'
+          echo "test=$test_result audit=$audit_result"
+          if [ "$test_result" != "success" ] || [ "$audit_result" != "success" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
First of five repos to grow the uniform `ci-summary` check that the org-level branch rulesets in `Declaratus/governance` will require by name. Once `plynth`, `governance`, `.github`, and both `aks-agent-platform` repos have it, a single follow-up PR adds `required_status_checks` to the three branch ruleset JSONs and closes the last box on the phase 1 tracker.

### What this adds

A `ci-summary` job in `.github/workflows/ci.yml` that depends on `test` and `audit` and only succeeds when both did.

### Why `if: always()` matters

Without it, a failed or cancelled upstream leaves `ci-summary` in `skipped` state, and GitHub treats a `skipped` required check as passing. The explicit per-`needs.*.result` comparison (rather than `contains(needs.*.result, ''failure'')`) catches `cancelled` and `skipped` too, not just outright failures.

This is the spec 01 risk #3 mitigation, documented in `Declaratus/governance` `RUNBOOKS/ruleset-rollout.md` § Status checks and the spec 05 design.

### Sequencing

Lands first because plynth is already public and the smallest CI surface. Other four repos follow on the same pattern. The branch ruleset PR comes last so we never have a required check that doesn''t exist.

Refs Declaratus/governance#5