### PR TITLE
fix(engine): distinguish permission-denied from rate-limited 403s (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **403 retry policy split** (#41). `_handle_retry` previously retried any
+  403 the same way it retried 429/502/503. GitHub uses 403 for two unrelated
+  cases: rate limits / abuse detection (retryable) and permission denials
+  (not). Plynth now only retries 403s that carry a positive rate-limit
+  signal: `Retry-After` header, `X-RateLimit-Remaining: 0`, or a
+  secondary-rate-limit phrase in the response body. Permission-denied 403s
+  raise `AuthError` immediately with a pointer at SECURITY.md, instead of
+  surfacing "Max retries exceeded" after spinning the loop. Repro that
+  motivated the fix: a fine-grained PAT without repository Issues access
+  used to fail Phase 2 milestone creation as a transient-looking timeout;
+  now it fails fast with permission advice.
 - **401 error wording** (#40). Both the GraphQL and REST 401 handlers
   now point at SECURITY.md and name all three supported token shapes
   (classic PAT, fine-grained PAT, GitHub App). Pre-#40 they only

--- a/plynth/engine/api_base.py
+++ b/plynth/engine/api_base.py
@@ -53,6 +53,32 @@ def derive_api_roots(target: str) -> tuple[str, str]:
     return (f"{stripped}/api/graphql", f"{stripped}/api/v3")
 
 
+# GitHub uses 403 for two unrelated cases: rate limit / abuse detection
+# (retryable) and permission denial (not retryable). The signals below are
+# the canonical rate-limit shapes from GitHub's REST docs; their absence
+# means a permission denial that the retry loop can't fix.
+_SECONDARY_RATE_LIMIT_PHRASES = ("secondary rate limit", "abuse detection")
+
+
+def is_rate_limited_403(response: requests.Response) -> bool:
+    """True iff a 403 response carries a positive rate-limit signal.
+
+    Checks three places, any one of which is enough: ``Retry-After`` header,
+    ``X-RateLimit-Remaining: 0`` (primary rate limit), or one of the
+    secondary-rate-limit phrases in the response body's ``message``.
+    """
+    if response.headers.get("Retry-After"):
+        return True
+    if response.headers.get("X-RateLimit-Remaining") == "0":
+        return True
+    try:
+        message = (response.json() or {}).get("message", "")
+    except ValueError:
+        message = ""
+    lower = message.lower() if isinstance(message, str) else ""
+    return any(phrase in lower for phrase in _SECONDARY_RATE_LIMIT_PHRASES)
+
+
 class GitHubClient:
     """Base HTTP client for GitHub.com or GHES with rate limiting and retry."""
 
@@ -138,8 +164,13 @@ class GitHubClient:
     def _handle_retry(self, response: requests.Response, attempt: int) -> bool:
         """Check if we should retry based on rate limit headers.
 
-        Returns True if the caller should retry the request.
+        Returns True if the caller should retry the request. A 403 only
+        counts as retryable when ``is_rate_limited_403`` confirms a rate
+        limit shape; permission-denied 403s fall through so the caller can
+        raise ``AuthError`` instead of spinning the retry loop.
         """
+        if response.status_code == 403 and not is_rate_limited_403(response):
+            return False
         if response.status_code in (429, 403, 502, 503):
             retry_after = response.headers.get("Retry-After")
             if retry_after:

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -77,8 +77,9 @@ class GraphQLClient:
                 raise AuthError(token_rejected_message(self.base.display_target))
 
             if response.status_code == 403 and not is_rate_limited_403(response):
+                operation = "GraphQL mutation" if is_mutation else "GraphQL query"
                 raise AuthError(
-                    permission_denied_message(self.base.display_target, "GraphQL mutation")
+                    permission_denied_message(self.base.display_target, operation)
                 )
 
             if not self.base._handle_retry(response, attempt):

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -78,9 +78,7 @@ class GraphQLClient:
 
             if response.status_code == 403 and not is_rate_limited_403(response):
                 operation = "GraphQL mutation" if is_mutation else "GraphQL query"
-                raise AuthError(
-                    permission_denied_message(self.base.display_target, operation)
-                )
+                raise AuthError(permission_denied_message(self.base.display_target, operation))
 
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()

--- a/plynth/engine/graphql_client.py
+++ b/plynth/engine/graphql_client.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import requests
 
-from plynth.engine.api_base import GitHubClient
+from plynth.engine.api_base import GitHubClient, is_rate_limited_403
 from plynth.errors import (
     AuthError,
     NetworkError,
     NotFoundError,
     PlynthError,
+    permission_denied_message,
     token_rejected_message,
 )
 from plynth.queries import mutations, queries
@@ -74,6 +75,11 @@ class GraphQLClient:
 
             if response.status_code == 401:
                 raise AuthError(token_rejected_message(self.base.display_target))
+
+            if response.status_code == 403 and not is_rate_limited_403(response):
+                raise AuthError(
+                    permission_denied_message(self.base.display_target, "GraphQL mutation")
+                )
 
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -184,7 +184,8 @@ class RESTClient:
                     f"Permission denied by {self.base.display_target} creating repo "
                     f"'{org}/{name}': the token is authenticated but lacks the required "
                     f"permissions. Repo creation needs `repo` (classic) or organization "
-                    f"Administration: Read and write (fine-grained). See SECURITY.md."
+                    f"Administration: Read and write (fine-grained). See "
+                    f"SECURITY.md#token-handling."
                 )
 
             if not self.base._handle_retry(response, attempt):

--- a/plynth/engine/rest_client.py
+++ b/plynth/engine/rest_client.py
@@ -4,8 +4,14 @@ import logging
 
 import requests
 
-from plynth.engine.api_base import GitHubClient
-from plynth.errors import AuthError, NetworkError, NotFoundError, token_rejected_message
+from plynth.engine.api_base import GitHubClient, is_rate_limited_403
+from plynth.errors import (
+    AuthError,
+    NetworkError,
+    NotFoundError,
+    permission_denied_message,
+    token_rejected_message,
+)
 
 
 class RESTClient:
@@ -115,6 +121,12 @@ class RESTClient:
                 raise NotFoundError(
                     f"Repository {owner}/{repo} not found on {self.base.display_target}"
                 )
+            if response.status_code == 403 and not is_rate_limited_403(response):
+                raise AuthError(
+                    permission_denied_message(
+                        self.base.display_target, f"creating milestone '{title}'"
+                    )
+                )
 
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()
@@ -167,6 +179,13 @@ class RESTClient:
                 )
             if response.status_code == 404:
                 raise NotFoundError(f"Organization {org} not found on {self.base.display_target}")
+            if response.status_code == 403 and not is_rate_limited_403(response):
+                raise AuthError(
+                    f"Permission denied by {self.base.display_target} creating repo "
+                    f"'{org}/{name}': the token is authenticated but lacks the required "
+                    f"permissions. Repo creation needs `repo` (classic) or organization "
+                    f"Administration: Read and write (fine-grained). See SECURITY.md."
+                )
 
             if not self.base._handle_retry(response, attempt):
                 response.raise_for_status()

--- a/plynth/errors.py
+++ b/plynth/errors.py
@@ -63,8 +63,9 @@ def permission_denied_message(display_target: str, operation: str) -> str:
         f"Permission denied by {display_target} on {operation}: the token is "
         f"authenticated but lacks the required permissions. plynth needs "
         f"repository Issues: Read and write plus organization Projects: Read "
-        f"and write (fine-grained PAT), or `repo` + `project` scopes (classic "
-        f"PAT). See SECURITY.md#token-handling."
+        f"and write (fine-grained PAT), `repo` + `project` scopes (classic "
+        f"PAT), or the equivalent installation permissions (GitHub App). See "
+        f"SECURITY.md#token-handling."
     )
 
 

--- a/plynth/errors.py
+++ b/plynth/errors.py
@@ -45,6 +45,29 @@ def token_rejected_message(display_target: str) -> str:
     )
 
 
+def permission_denied_message(display_target: str, operation: str) -> str:
+    """Standard 403 advice when the token is valid but lacks permissions.
+
+    GitHub returns 403 for two unrelated cases: rate-limit / abuse detection
+    (handled in ``api_base.is_rate_limited_403``) and permission denials.
+    When the response carries no rate-limit signal, the token is authenticated
+    but the permission set is wrong, which the retry loop can never fix.
+    Surface that as ``AuthError`` with a pointer at SECURITY.md so the user
+    isn't told "max retries exceeded" for a permanent condition.
+
+    ``operation`` describes the call that was denied (e.g. "creating
+    milestone", "GraphQL mutation") so the user can map the failure to the
+    permission row in SECURITY.md.
+    """
+    return (
+        f"Permission denied by {display_target} on {operation}: the token is "
+        f"authenticated but lacks the required permissions. plynth needs "
+        f"repository Issues: Read and write plus organization Projects: Read "
+        f"and write (fine-grained PAT), or `repo` + `project` scopes (classic "
+        f"PAT). See SECURITY.md#token-handling."
+    )
+
+
 __all__ = [
     "PlynthError",
     "AuthError",
@@ -52,4 +75,5 @@ __all__ = [
     "NetworkError",
     "ConfigError",
     "token_rejected_message",
+    "permission_denied_message",
 ]

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import responses
 
-from plynth.engine.api_base import GHESClient, GitHubClient
+from plynth.engine.api_base import GHESClient, GitHubClient, is_rate_limited_403
 
 
 def test_auth_header_set() -> None:
@@ -203,3 +203,123 @@ def test_handle_retry_returns_false_on_200() -> None:
         return client._handle_retry(r, attempt=0)
 
     assert _do() is False
+
+
+# ── 403 retry policy (#41) ─────────────────────────────────────
+#
+# GitHub uses 403 for both rate-limit / abuse detection (retryable) and
+# permission denial (not retryable). The retry helper only retries 403s that
+# carry one of the canonical rate-limit signals; everything else falls
+# through so the caller can raise AuthError.
+
+
+def test_handle_retry_403_with_retry_after_retries() -> None:
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(
+            responses.GET,
+            "https://ghes.example.com/api/test",
+            status=403,
+            headers={"Retry-After": "0"},
+        )
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep"):
+            return client._handle_retry(r, attempt=0)
+
+    assert _do() is True
+
+
+def test_handle_retry_403_with_zero_rate_limit_remaining_retries() -> None:
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(
+            responses.GET,
+            "https://ghes.example.com/api/test",
+            status=403,
+            headers={"X-RateLimit-Remaining": "0"},
+        )
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep"):
+            return client._handle_retry(r, attempt=0)
+
+    assert _do() is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+        "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.",
+    ],
+)
+def test_handle_retry_403_with_rate_limit_body_message_retries(message: str) -> None:
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(
+            responses.GET,
+            "https://ghes.example.com/api/test",
+            status=403,
+            json={"message": message},
+        )
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep"):
+            return client._handle_retry(r, attempt=0)
+
+    assert _do() is True
+
+
+def test_handle_retry_403_permission_denied_returns_false() -> None:
+    """No rate-limit signals → permission denial. Don't sleep, don't retry."""
+    client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+
+    @responses.activate
+    def _do() -> bool:
+        responses.add(
+            responses.GET,
+            "https://ghes.example.com/api/test",
+            status=403,
+            json={"message": "Resource not accessible by integration"},
+        )
+        r = client.session.get("https://ghes.example.com/api/test")
+        with patch("plynth.engine.api_base.time.sleep") as mock_sleep:
+            should_retry = client._handle_retry(r, attempt=0)
+            mock_sleep.assert_not_called()
+        return should_retry
+
+    assert _do() is False
+
+
+@pytest.mark.parametrize(
+    "headers,body,expected",
+    [
+        ({"Retry-After": "5"}, None, True),
+        ({"X-RateLimit-Remaining": "0"}, None, True),
+        ({"X-RateLimit-Remaining": "42"}, None, False),
+        ({}, {"message": "You have exceeded a secondary rate limit."}, True),
+        ({}, {"message": "abuse detection mechanism triggered"}, True),
+        ({}, {"message": "Resource not accessible by integration"}, False),
+        ({}, None, False),
+    ],
+)
+def test_is_rate_limited_403_signal_matrix(
+    headers: dict[str, str], body: dict | None, expected: bool
+) -> None:
+    """Single source of truth for the retry-vs-deny decision rule."""
+
+    @responses.activate
+    def _do() -> bool:
+        kwargs: dict = {"status": 403, "headers": headers}
+        if body is not None:
+            kwargs["json"] = body
+        responses.add(responses.GET, "https://ghes.example.com/api/test", **kwargs)
+        client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
+        r = client.session.get("https://ghes.example.com/api/test")
+        return is_rate_limited_403(r)
+
+    assert _do() is expected

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -249,13 +249,15 @@ def test_handle_retry_403_with_zero_rate_limit_remaining_retries() -> None:
     assert _do() is True
 
 
-@pytest.mark.parametrize(
-    "message",
-    [
-        "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
-        "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.",
-    ],
-)
+# Real GitHub phrasing trimmed to fit the line-length cap; the case-insensitive
+# substring match in is_rate_limited_403 keys on the canonical phrases here.
+_SECONDARY_RATE_LIMIT_BODIES = [
+    "You have exceeded a secondary rate limit.",
+    "You have triggered an abuse detection mechanism.",
+]
+
+
+@pytest.mark.parametrize("message", _SECONDARY_RATE_LIMIT_BODIES)
 def test_handle_retry_403_with_rate_limit_body_message_retries(message: str) -> None:
     client = GitHubClient("https://ghes.example.com", "tok", write_delay_ms=0)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -38,6 +38,18 @@ def _assert_token_rejected_wording(msg: str) -> None:
     assert "SECURITY.md" in msg
 
 
+def _assert_permission_denied_wording(msg: str) -> None:
+    """Pin the wording produced by ``permission_denied_message`` (#41).
+
+    Permission-denied 403s must read distinctly from 401 token-rejected — a
+    user staring at the message should be able to tell that the token is
+    valid but lacks permissions. SECURITY.md must be referenced.
+    """
+    assert "Permission denied" in msg
+    assert "lacks the required permissions" in msg
+    assert "SECURITY.md" in msg
+
+
 def test_error_hierarchy() -> None:
     # All friendly errors are PlynthError; GraphQLError is also PlynthError now.
     for exc_cls in (AuthError, NotFoundError, NetworkError, GraphQLError):
@@ -53,6 +65,42 @@ def test_graphql_401_raises_auth_error() -> None:
     with pytest.raises(AuthError) as excinfo:
         _gql().get_org_id("nope")
     _assert_token_rejected_wording(str(excinfo.value))
+
+
+@responses.activate
+def test_graphql_403_permission_denied_raises_auth_error() -> None:
+    """No rate-limit signals: surface AuthError immediately, don't burn retries."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _gql().get_org_id("nope")
+    _assert_permission_denied_wording(str(excinfo.value))
+    # Only one call — no retry loop on a permanent condition.
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_graphql_403_rate_limited_retries_then_succeeds() -> None:
+    """A 403 with a rate-limit signal must retry and succeed on the next try."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=403,
+        headers={"Retry-After": "0"},
+        json={"message": "secondary rate limit"},
+    )
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=200,
+        json={"data": {"organization": {"id": "O_1"}}},
+    )
+    assert _gql().get_org_id("example-org") == "O_1"
+    assert len(responses.calls) == 2
 
 
 @responses.activate
@@ -152,6 +200,65 @@ def test_rest_401_raises_auth_error() -> None:
     # REST and GraphQL share the same helper, so they MUST produce the
     # same wording — pin both with the shared assertion.
     _assert_token_rejected_wording(str(excinfo.value))
+
+
+@responses.activate
+def test_rest_milestone_403_permission_denied_raises_auth_error() -> None:
+    """Repro of the bug in #41: a permission-denied 403 surfaces as AuthError
+    pointing at SECURITY.md, not as 'Max retries exceeded'."""
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _rest().create_milestone(owner="example-org", repo="acme", title="Acme Foundation")
+    msg = str(excinfo.value)
+    _assert_permission_denied_wording(msg)
+    # The operation name is folded into the message so a user with multiple
+    # phases failing can map back to the call site.
+    assert "Acme Foundation" in msg
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_rest_milestone_403_rate_limited_retries_then_succeeds() -> None:
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        status=403,
+        headers={"Retry-After": "0"},
+        json={"message": "You have exceeded a secondary rate limit."},
+    )
+    responses.add(
+        responses.POST,
+        MILESTONE_URL,
+        status=201,
+        json={"number": 3, "node_id": "MI_1", "title": "T"},
+    )
+    result = _rest().create_milestone(owner="example-org", repo="acme", title="T")
+    assert result == {"number": 3, "node_id": "MI_1", "title": "T"}
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_rest_create_repo_403_permission_denied_raises_auth_error() -> None:
+    """create_repo keeps its operation-specific Administration wording."""
+    repo_url = f"{GHES_URL}/api/v3/orgs/example-org/repos"
+    responses.add(
+        responses.POST,
+        repo_url,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _rest().create_repo(org="example-org", name="acme")
+    msg = str(excinfo.value)
+    assert "Permission denied" in msg
+    assert "Administration: Read and write" in msg
+    assert "SECURITY.md" in msg
+    assert len(responses.calls) == 1
 
 
 @responses.activate

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -84,6 +84,53 @@ def test_graphql_403_permission_denied_raises_auth_error() -> None:
 
 
 @responses.activate
+def test_graphql_403_labels_query_vs_mutation_correctly() -> None:
+    """The 403 message names ``GraphQL query`` on read paths and
+    ``GraphQL mutation`` on write paths, so the operation tag in the error
+    matches the actual request type."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _gql().get_org_id("nope")  # query
+    assert "GraphQL query" in str(excinfo.value)
+    assert "GraphQL mutation" not in str(excinfo.value)
+
+    responses.reset()
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _gql().create_project(owner_id="O_1", title="T")  # mutation
+    assert "GraphQL mutation" in str(excinfo.value)
+
+
+@responses.activate
+def test_permission_denied_message_names_all_three_token_shapes() -> None:
+    """Parallel to the 401 token-rejected wording, the 403 advice names
+    fine-grained PAT, classic PAT, and GitHub App so a user with any shape
+    sees themselves in the advice."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        status=403,
+        json={"message": "Resource not accessible by integration"},
+    )
+    with pytest.raises(AuthError) as excinfo:
+        _gql().get_org_id("nope")
+    msg = str(excinfo.value)
+    assert "fine-grained PAT" in msg
+    assert "classic PAT" in msg
+    assert "GitHub App" in msg
+
+
+@responses.activate
 def test_graphql_403_rate_limited_retries_then_succeeds() -> None:
     """A 403 with a rate-limit signal must retry and succeed on the next try."""
     responses.add(


### PR DESCRIPTION
Closes #41.

`_handle_retry` retried any 403 the same way it retried 429/502/503. GitHub uses 403 for two unrelated cases: rate limits / abuse detection (retryable) and permission denials (not). A permission-denied 403 (fine-grained PAT without Issues access on Phase 2 milestone creation, per the issue's repro) burned through retries and surfaced as 'Max retries exceeded', reading like a transient failure.

## Decision rule

A 403 is retryable only when one of the three GitHub-canonical rate-limit signals is present:

- `Retry-After` header
- `X-RateLimit-Remaining: 0` (primary rate limit)
- response body `message` contains `secondary rate limit` or `abuse detection` (case-insensitive)

Everything else falls through to a new `permission_denied_message()` -> `AuthError` raise, parallel to the existing 401 path. The retry helper itself also returns False on a permission-denied 403, belt-and-suspenders against future callers.

## Files

- `plynth/errors.py` — `permission_denied_message(display_target, operation)` + `__all__` export. No new error class; reuses `AuthError` per PR #58 alignment.
- `plynth/engine/api_base.py` — module-level `is_rate_limited_403(response)` helper, `_handle_retry` gates 403 on it.
- `plynth/engine/graphql_client.py` — adds the 403 -> AuthError raise after the existing 401 check.
- `plynth/engine/rest_client.py` — same for `create_milestone`. `create_repo` keeps its operation-specific Administration wording (the permission a 403 there actually points at is org Administration, not Issues / Projects).
- `tests/test_api_base.py` — new tests for the three retry signals, permission-denied returns False, plus a parametrized matrix on `is_rate_limited_403`.
- `tests/test_errors.py` — pins the new wording for GraphQL and REST 403 paths, plus retry-then-success cases for rate-limited 403s.
- `CHANGELOG.md` — Unreleased / Changed entry.

239 passed, 2 skipped.