### PR TITLE
chore(models): schema_version cadence and load-path compat shims (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **schema_version cadence and load-path compat shims** (#45). The
+  template-level `schema_version` field now defaults to `"1.0"`, so
+  pre-M1 templates without the key keep parsing. M1 templates should
+  declare `schema_version: "1.1"` to flag use of `defaults:`, rich
+  `FieldOption`, and the `reconciliation:` stub; the engine accepts the
+  string verbatim. The version cadence (1.0 through 1.5, with M2-M5
+  planned) is documented in `docs/plynth-design-spec.md#schema-versioning`.
+  State-file shape migrations now live in
+  `StateFile._apply_compat_shims`, a single funnel for renames and
+  relocations; the pre-v0.3 `ghes_url` → `target` rename moves under
+  the new docstring. Pydantic defaults zero-fill genuinely additive
+  fields, so M1+ keys absent from a v0.3-era state file load cleanly.
+  Regression fixture: `tests/fixtures/v0_3-state.yaml` round-trips
+  through `model_validate` / `model_dump` under the current schema.
 - **401 error wording** (#40). Both the GraphQL and REST 401 handlers
   now point at SECURITY.md and name all three supported token shapes
   (classic PAT, fine-grained PAT, GitHub App). Pre-#40 they only

--- a/docs/plynth-design-spec.md
+++ b/docs/plynth-design-spec.md
@@ -64,6 +64,25 @@ The tool reads a **template definition** (YAML) and an **instance config** (YAML
 
 ---
 
+## Schema versioning
+
+Templates and state files carry a `schema_version` string so older artifacts keep parsing across plynth releases. Templates that omit the key are parsed as `1.0` (pre-M1); state files default the same way.
+
+| version | adds |
+|---------|------|
+| `1.0` | base schema (pre-M1): placeholders, fields, milestones, issues, views, pruning, optional `status:` block |
+| `1.1` | M1: template-level `defaults:`, rich `FieldOption` (color/description/default/aliases/deprecated), `reconciliation:` stub |
+| `1.2` | M2: `labels:` catalogue, issue `labels` / `issue_type` (planned) |
+| `1.3` | M3: `label_rules:` (planned) |
+| `1.4` | M4: instance `label_overrides` / `issue_overrides` (planned) |
+| `1.5` | M5: verifier subcommand and `VerifyReport` (planned) |
+
+The engine accepts an M1 template either with or without `schema_version: "1.1"` today; the table is the contract for what each version adds, not a runtime gate. Templates that intend to use a future-version feature should declare the matching version so the contract is auditable in the file.
+
+State-file migrations live in `StateFile._apply_compat_shims` (`plynth/models/state.py`). It owns every dict-shape transformation needed to upgrade an older state file into the current in-memory shape (e.g. the pre-v0.3 `ghes_url` → `target` rename). Pydantic field defaults zero-fill missing keys, so genuinely additive M1+ fields need no shim, just a default on the model.
+
+---
+
 ## Template Definition Schema
 
 This is the machine-readable source of truth. One file per template, version-controlled in the repository.

--- a/plynth/models/state.py
+++ b/plynth/models/state.py
@@ -96,14 +96,34 @@ class StateFile(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _migrate_legacy_ghes_url(cls, data: Any) -> Any:
-        """v0.2.0 state files used `ghes_url`. Silently rename to `target` so
-        in-flight runs keep resuming after the v0.3.0 upgrade. State files are
-        machine-written; a hard rename would gratuitously break resume."""
-        if isinstance(data, dict) and "ghes_url" in data:
-            data = {**data}
+    def _apply_compat_shims(cls, data: Any) -> Any:
+        """Single funnel for state-file shape migrations across schema_version.
+
+        State files are machine-written, so a hard schema rename would break
+        in-flight resume across a plynth upgrade. This hook owns every dict
+        transformation needed to upgrade an older state file into the current
+        in-memory shape. Pydantic field defaults handle zero-filling missing
+        keys; this hook is for renames, relocations, and structural changes
+        that defaults can't express.
+
+        Shims, oldest first:
+
+        - pre-v0.3 (``ghes_url`` key): renamed to ``target`` in v0.3. The new
+          ``target`` key wins if both are somehow present.
+
+        See ``docs/plynth-design-spec.md#schema-versioning`` for the cadence
+        and which schema_version each shim corresponds to.
+        """
+        if not isinstance(data, dict):
+            return data
+        data = {**data}
+
+        # pre-v0.3 → v0.3+: ghes_url renamed to target. setdefault preserves
+        # any explicit target= that's already present.
+        if "ghes_url" in data:
             legacy = data.pop("ghes_url")
             data.setdefault("target", legacy)
+
         return data
 
     schema_version: str = "1.0"

--- a/plynth/models/template.py
+++ b/plynth/models/template.py
@@ -185,7 +185,12 @@ class ReconciliationConfig(BaseModel):
 class TemplateDefinition(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: str
+    # See docs/plynth-design-spec.md#schema-versioning for the cadence.
+    # A template that omits `schema_version` is parsed as "1.0" (pre-M1).
+    # M1+ features (`defaults`, rich `FieldOption`, `reconciliation`) should
+    # declare `schema_version: "1.1"`; today the engine accepts them either
+    # way, but the table is the source of truth for what each version adds.
+    schema_version: str = "1.0"
     template: TemplateMetadata
     placeholders: dict[str, PlaceholderSpec] = {}
     status: list[FieldOption] = []

--- a/tests/fixtures/v0_3-state.yaml
+++ b/tests/fixtures/v0_3-state.yaml
@@ -1,9 +1,13 @@
 # Hand-written v0.3-era state fixture used by the schema_version compat-shim
-# regression test. Pre-M1 shape: no status_field_id, no schema_version on
-# nested submodels, only fields that shipped through v0.3.x.
+# regression test. Pre-M1 shape: no status_field_id, no fields introduced
+# in M1+ — only keys that shipped through v0.3.x.
 #
 # StateFile must round-trip this through model_validate / model_dump under
-# the current (M1+) schema without losing data or rejecting unknown keys.
+# the current (M1+) schema without losing data. Every key here exists on
+# the current models (StateFile and its submodels are configured with
+# extra="forbid", so unknown keys would still be rejected); the round-trip
+# property under test is that M1+ keys absent from a v0.3 file zero-fill
+# cleanly via pydantic field defaults.
 
 schema_version: "1.0"
 created_at: "2026-05-01T10:00:00+00:00"

--- a/tests/fixtures/v0_3-state.yaml
+++ b/tests/fixtures/v0_3-state.yaml
@@ -1,0 +1,60 @@
+# Hand-written v0.3-era state fixture used by the schema_version compat-shim
+# regression test. Pre-M1 shape: no status_field_id, no schema_version on
+# nested submodels, only fields that shipped through v0.3.x.
+#
+# StateFile must round-trip this through model_validate / model_dump under
+# the current (M1+) schema without losing data or rejecting unknown keys.
+
+schema_version: "1.0"
+created_at: "2026-05-01T10:00:00+00:00"
+updated_at: "2026-05-01T10:05:00+00:00"
+template_sha256: "abc123"
+instance_sha256: "def456"
+template:
+  file: "templates/onboarding.yaml"
+  version: "v1"
+instance:
+  file: "instances/acme.yaml"
+  config_hash: "deadbeef"
+target: "https://ghes.example.com"
+org: "example-org"
+repo:
+  name: "acme-service"
+  node_id: "R_kgDOExample"
+project:
+  node_id: "PVT_kwDOExample"
+  url: "https://ghes.example.com/orgs/example-org/projects/12"
+  number: 12
+fields:
+  workstream:
+    node_id: "PVTSSF_workstream"
+    options:
+      Documentation: "opt_doc"
+      Infrastructure: "opt_infra"
+milestones:
+  M1:
+    number: 3
+    node_id: "MI_M1"
+    title: "M1: Repository and Documentation Foundation"
+issues:
+  "001":
+    number: 47
+    node_id: "I_001"
+    item_id: "PVTI_001"
+    title: "ACME-001: Create acme-service repository"
+    body_sha256: "fedcba"
+dependencies_created:
+  - blocker: "001"
+    blocked: "002"
+skipped:
+  milestones: ["M2"]
+  issues: []
+phases:
+  phase_1_project_and_fields:
+    completed: true
+    completed_at: "2026-05-01T10:01:00+00:00"
+    error: null
+  phase_3_issues:
+    completed: false
+    completed_at: null
+    error: "Connection reset by peer"

--- a/tests/test_models_state.py
+++ b/tests/test_models_state.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import yaml
+
 from plynth.models.state import (
     PHASE_1_PROJECT_AND_FIELDS,
     PHASE_3_ISSUES,
     StateFile,
 )
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_default_schema_version() -> None:
@@ -70,3 +76,34 @@ def test_legacy_ghes_url_does_not_override_target_if_both_present() -> None:
     }
     s = StateFile.model_validate(data)
     assert s.target == "https://new.example.com"
+
+
+# ── #45: schema_version cadence ────────────────────────────────────
+
+
+def test_v0_3_state_fixture_round_trips() -> None:
+    """A hand-written v0.3-era state file (pre-M1 shape) must load cleanly
+    under the current schema and survive a model_dump / model_validate cycle
+    without losing data. Regression guard for the compat-shim layer in
+    ``StateFile._apply_compat_shims``."""
+    raw = yaml.safe_load((FIXTURES / "v0_3-state.yaml").read_text(encoding="utf-8"))
+    loaded = StateFile.model_validate(raw)
+
+    assert loaded.schema_version == "1.0"
+    assert loaded.target == "https://ghes.example.com"
+    assert loaded.org == "example-org"
+    assert loaded.repo is not None and loaded.repo.name == "acme-service"
+    assert loaded.project is not None and loaded.project.number == 12
+    assert "workstream" in loaded.fields
+    assert loaded.fields["workstream"].options["Documentation"] == "opt_doc"
+    assert loaded.milestones["M1"].number == 3
+    assert loaded.issues["001"].number == 47
+    assert loaded.is_phase_complete(PHASE_1_PROJECT_AND_FIELDS)
+    assert not loaded.is_phase_complete(PHASE_3_ISSUES)
+    assert loaded.phases[PHASE_3_ISSUES].error == "Connection reset by peer"
+    # M1+ field absent from the v0.3 fixture must zero-fill cleanly.
+    assert loaded.status_field_id is None
+
+    # Dump and reload to confirm the result is itself a valid StateFile dict.
+    rebuilt = StateFile.model_validate(loaded.model_dump())
+    assert rebuilt.model_dump() == loaded.model_dump()

--- a/tests/test_models_template.py
+++ b/tests/test_models_template.py
@@ -274,3 +274,29 @@ def test_reconciliation_invalid_mode_rejected() -> None:
     data["reconciliation"] = {"mode": "apply"}
     with pytest.raises(ValidationError):
         TemplateDefinition.model_validate(data)
+
+
+# ── #45: schema_version cadence ────────────────────────────────────
+
+
+def test_template_missing_schema_version_defaults_to_1_0() -> None:
+    """Pre-M1 templates omit `schema_version`. The default keeps them parsing."""
+    data = _base_template_dict()
+    data.pop("schema_version")
+    t = TemplateDefinition.model_validate(data)
+    assert t.schema_version == "1.0"
+
+
+def test_template_schema_version_1_1_loads() -> None:
+    """M1 templates declare `schema_version: '1.1'` to flag use of defaults,
+    rich FieldOption, and the reconciliation stub. The engine accepts the
+    string verbatim; the design-spec table is the contract for what each
+    version unlocks."""
+    data = _base_template_dict()
+    data["schema_version"] = "1.1"
+    data["defaults"] = {"fields": {"priority": "P1"}}
+    data["reconciliation"] = {"mode": "report_only"}
+    t = TemplateDefinition.model_validate(data)
+    assert t.schema_version == "1.1"
+    assert t.defaults.fields == {"priority": "P1"}
+    assert t.reconciliation.mode == "report_only"


### PR DESCRIPTION
Closes #45.

Templates that omit `schema_version` now parse as `1.0` instead of raising. M1 templates declare `schema_version: "1.1"` to flag use of `defaults:`, rich `FieldOption`, and the `reconciliation:` stub.

## What landed

- **docs/plynth-design-spec.md** gains a Schema Versioning section between the architecture diagram and the Template Definition Schema, with the 1.0 to 1.5 cadence as a table. M2-M5 are planned.
- **plynth/models/template.py** `TemplateDefinition.schema_version` defaults to `"1.0"` so pre-M1 templates without the key parse. Pydantic v2 zero-fills via the field default; no `model_validator(mode="before")` needed for this case.
- **plynth/models/state.py** the existing `_migrate_legacy_ghes_url` validator is renamed `_apply_compat_shims` and reframed as the single funnel for state-file shape migrations across `schema_version`. The pre-v0.3 `ghes_url` → `target` rename moves under the new docstring. State-file field defaults already zero-fill M1+ keys, so genuinely additive fields need no shim; this hook is for renames, relocations, and structural changes defaults can't express.
- **tests/fixtures/v0_3-state.yaml** hand-written pre-M1 state fixture.
- **tests/test_models_template.py** + **tests/test_models_state.py** new tests for: missing `schema_version` defaults to 1.0, `1.1` template loads, v0.3 fixture round-trips through `model_validate` / `model_dump`.
- **CHANGELOG.md** Unreleased / Changed entry.

## Decision: no soft warning today

The issue notes "Templates declare schema_version: '1.1' to use M1 features". The engine accepts an M1 template either with or without `1.1` today; the design-spec table is the contract, not a runtime gate. A soft warning when M1 fields appear under `1.0` is doable but feels like noise for a one-off transitional period. Leaving it out unless we get a report of someone confused by the loose acceptance.

225 passed, 2 skipped.